### PR TITLE
Enable Gemma3 270M

### DIFF
--- a/.github/workflows/test_models.yml
+++ b/.github/workflows/test_models.yml
@@ -36,7 +36,7 @@ jobs:
         test-modeling: ${{ fromJson(needs.discover-tests.outputs.model_names) }}
         executorch-version: ['0.6.0', 'nightly']
         python-version: ['3.11']
-        os: [macos-15-large, ubuntu-22.04]
+        os: [macos-15, ubuntu-22.04]
 
     # Custom job name, now shortened and cleaner
     name: ${{ matrix.test-modeling }} (et=${{ matrix.executorch-version }}, py=${{ matrix.python-version }}, ${{ matrix.os }})

--- a/.github/workflows/test_models.yml
+++ b/.github/workflows/test_models.yml
@@ -36,7 +36,7 @@ jobs:
         test-modeling: ${{ fromJson(needs.discover-tests.outputs.model_names) }}
         executorch-version: ['0.6.0', 'nightly']
         python-version: ['3.11']
-        os: [macos-15, ubuntu-22.04]
+        os: [macos-15-large, ubuntu-22.04]
 
     # Custom job name, now shortened and cleaner
     name: ${{ matrix.test-modeling }} (et=${{ matrix.executorch-version }}, py=${{ matrix.python-version }}, ${{ matrix.os }})

--- a/.github/workflows/test_models.yml
+++ b/.github/workflows/test_models.yml
@@ -34,9 +34,10 @@ jobs:
       fail-fast: false
       matrix:
         test-modeling: ${{ fromJson(needs.discover-tests.outputs.model_names) }}
-        executorch-version: ['0.6.0', 'nightly']
+        executorch-version: ['0.7.0', 'nightly']
         python-version: ['3.11']
-        os: [macos-15, ubuntu-22.04]
+        # os: [macos-15, ubuntu-22.04]  # TODO(#122): Re-enable the mac tests after fixing seg fault.
+        os: [ubuntu-22.04]
 
     # Custom job name, now shortened and cleaner
     name: ${{ matrix.test-modeling }} (et=${{ matrix.executorch-version }}, py=${{ matrix.python-version }}, ${{ matrix.os }})

--- a/.github/workflows/test_models.yml
+++ b/.github/workflows/test_models.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         test-modeling: ${{ fromJson(needs.discover-tests.outputs.model_names) }}
-        executorch-version: ['0.6.0', 'nightly']
+        executorch-version: ['0.7.0', 'nightly']
         python-version: ['3.11']
         os: [macos-15, ubuntu-22.04]
 

--- a/.github/workflows/test_models.yml
+++ b/.github/workflows/test_models.yml
@@ -36,7 +36,8 @@ jobs:
         test-modeling: ${{ fromJson(needs.discover-tests.outputs.model_names) }}
         executorch-version: ['0.7.0', 'nightly']
         python-version: ['3.11']
-        os: [macos-15, ubuntu-22.04]
+        # os: [macos-15, ubuntu-22.04]  # TODO(#122): Re-enable the mac tests after fixing seg fault.
+        os: [ubuntu-22.04]
 
     # Custom job name, now shortened and cleaner
     name: ${{ matrix.test-modeling }} (et=${{ matrix.executorch-version }}, py=${{ matrix.python-version }}, ${{ matrix.os }})

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ We currently support a wide range of popular transformer models, including encod
 - [Codegen](https://huggingface.co/Salesforce/codegen-350M-mono): Salesforce's `codegen-350M-mono` and its variants
 - [Gemma](https://huggingface.co/google/gemma-2b): `Gemma-2b` and its variants
 - [Gemma2](https://huggingface.co/google/gemma-2-2b): `Gemma-2-2b` and its variants
-- [Gemma3](https://huggingface.co/google/gemma-3-1b-it): `Gemma-3-1b` and its variants
+- [Gemma3](https://huggingface.co/google/gemma-3-1b-it): `Gemma-3-1b` and its variants (270M, 1B)
 - [Glm](https://huggingface.co/THUDM/glm-edge-1.5b-chat): `glm-edge-1.5b` and its variants
 - [Gpt2](https://huggingface.co/AI-Sweden-Models/gpt-sw3-126m): `gpt-sw3-126m` and its variants
 - [GptJ](https://huggingface.co/Milos/slovak-gpt-j-405M): `gpt-j-405M` and its variants

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ model = ExecuTorchModelForCausalLM.from_pretrained(
     recipe="xnnpack",
     attn_implementation="custom_sdpa",  # Use custom SDPA implementation for better performance
     use_custom_kv_cache=True,  # Use custom KV cache for better performance
-    **{"qlinear": True, "qembeeding": True},  # Quantize linear and embedding layers
+    **{"qlinear": "8da4w", "qembedding": "8w"},  # Quantize linear and embedding layers
 )
 
 # Generate text right away
@@ -90,8 +90,8 @@ optimum-cli export executorch \
     --recipe "xnnpack" \
     --use_custom_sdpa \
     --use_custom_kv_cache \
-    --qlinear \
-    --qembedding \
+    --qlinear 8da4w \
+    --qembedding 8w \
     --output_dir="hf_smollm2"
 ```
 Explore the various export options by running the command: `optimum-cli export executorch --help`

--- a/install_dev.py
+++ b/install_dev.py
@@ -5,21 +5,21 @@ import sys
 
 def install_torch_nightly_deps():
     """Install torch related dependencies from pinned nightly"""
-    EXECUTORCH_NIGHTLY_VERSION = "dev20250625"
-    TORCHAO_NIGHTLY_VERSION = "dev20250620"
+    EXECUTORCH_NIGHTLY_VERSION = "dev20250730"
+    TORCHAO_NIGHTLY_VERSION = "dev20250730"
     # Torch nightly is aligned with pinned nightly in https://github.com/pytorch/executorch/blob/main/install_requirements.py#L74
-    TORCH_NIGHTLY_VERSION = "dev20250601"
+    TORCH_NIGHTLY_VERSION = "dev20250725"
     subprocess.check_call(
         [
             sys.executable,
             "-m",
             "pip",
             "install",
-            f"executorch==0.7.0.{EXECUTORCH_NIGHTLY_VERSION}",
-            f"torch==2.8.0.{TORCH_NIGHTLY_VERSION}",
-            f"torchvision==0.23.0.{TORCH_NIGHTLY_VERSION}",
+            f"executorch==0.8.0.{EXECUTORCH_NIGHTLY_VERSION}",
+            f"torch==2.9.0.{TORCH_NIGHTLY_VERSION}",
+            f"torchvision==0.24.0.{TORCH_NIGHTLY_VERSION}",
             f"torchaudio==2.8.0.{TORCH_NIGHTLY_VERSION}",
-            f"torchao==0.12.0.{TORCHAO_NIGHTLY_VERSION}",
+            f"torchao==0.13.0.{TORCHAO_NIGHTLY_VERSION}",
             "--extra-index-url",
             "https://download.pytorch.org/whl/nightly/cpu",
         ]
@@ -34,7 +34,7 @@ def install_dep_from_source():
             "-m",
             "pip",
             "install",
-            "git+https://github.com/huggingface/transformers@896e9cea1ade521b2648f4798218550f6c72190c#egg=transformers",  # 4.53.1
+            "git+https://github.com/huggingface/transformers@9c641dc16154964e5ffc0c13e9ec6aaffa295ed6#egg=transformers",  # 4.54.1
         ]
     )
     subprocess.check_call(

--- a/install_dev.py
+++ b/install_dev.py
@@ -5,7 +5,7 @@ import sys
 
 def install_torch_nightly_deps():
     """Install torch related dependencies from pinned nightly"""
-    EXECUTORCH_NIGHTLY_VERSION = "dev20250628"
+    EXECUTORCH_NIGHTLY_VERSION = "dev20250626"
     TORCHAO_NIGHTLY_VERSION = "dev20250730"
     # Torch nightly is aligned with pinned nightly in https://github.com/pytorch/executorch/blob/main/install_requirements.py#L74
     TORCH_NIGHTLY_VERSION = "dev20250725"

--- a/install_dev.py
+++ b/install_dev.py
@@ -5,7 +5,7 @@ import sys
 
 def install_torch_nightly_deps():
     """Install torch related dependencies from pinned nightly"""
-    EXECUTORCH_NIGHTLY_VERSION = "dev20250625"
+    EXECUTORCH_NIGHTLY_VERSION = "dev20250730"
     TORCHAO_NIGHTLY_VERSION = "dev20250710"
     # Torch nightly is aligned with pinned nightly in https://github.com/pytorch/executorch/blob/main/install_requirements.py#L74
     TORCH_NIGHTLY_VERSION = "dev20250716"
@@ -15,7 +15,7 @@ def install_torch_nightly_deps():
             "-m",
             "pip",
             "install",
-            f"executorch==0.7.0.{EXECUTORCH_NIGHTLY_VERSION}",
+            f"executorch==0.8.0.{EXECUTORCH_NIGHTLY_VERSION}",
             f"torch==2.9.0.{TORCH_NIGHTLY_VERSION}",
             f"torchvision==0.24.0.{TORCH_NIGHTLY_VERSION}",
             f"torchaudio==2.8.0.{TORCH_NIGHTLY_VERSION}",

--- a/install_dev.py
+++ b/install_dev.py
@@ -5,7 +5,7 @@ import sys
 
 def install_torch_nightly_deps():
     """Install torch related dependencies from pinned nightly"""
-    EXECUTORCH_NIGHTLY_VERSION = "dev20250701"
+    EXECUTORCH_NIGHTLY_VERSION = "dev20250628"
     TORCHAO_NIGHTLY_VERSION = "dev20250730"
     # Torch nightly is aligned with pinned nightly in https://github.com/pytorch/executorch/blob/main/install_requirements.py#L74
     TORCH_NIGHTLY_VERSION = "dev20250725"
@@ -15,7 +15,7 @@ def install_torch_nightly_deps():
             "-m",
             "pip",
             "install",
-            f"executorch==0.8.0.{EXECUTORCH_NIGHTLY_VERSION}",
+            f"executorch==0.7.0.{EXECUTORCH_NIGHTLY_VERSION}",
             f"torch==2.9.0.{TORCH_NIGHTLY_VERSION}",
             f"torchvision==0.24.0.{TORCH_NIGHTLY_VERSION}",
             f"torchaudio==2.8.0.{TORCH_NIGHTLY_VERSION}",

--- a/install_dev.py
+++ b/install_dev.py
@@ -5,7 +5,7 @@ import sys
 
 def install_torch_nightly_deps():
     """Install torch related dependencies from pinned nightly"""
-    EXECUTORCH_NIGHTLY_VERSION = "dev20250628"
+    EXECUTORCH_NIGHTLY_VERSION = "dev20250701"
     TORCHAO_NIGHTLY_VERSION = "dev20250730"
     # Torch nightly is aligned with pinned nightly in https://github.com/pytorch/executorch/blob/main/install_requirements.py#L74
     TORCH_NIGHTLY_VERSION = "dev20250725"
@@ -15,7 +15,7 @@ def install_torch_nightly_deps():
             "-m",
             "pip",
             "install",
-            f"executorch==0.7.0.{EXECUTORCH_NIGHTLY_VERSION}",
+            f"executorch==0.8.0.{EXECUTORCH_NIGHTLY_VERSION}",
             f"torch==2.9.0.{TORCH_NIGHTLY_VERSION}",
             f"torchvision==0.24.0.{TORCH_NIGHTLY_VERSION}",
             f"torchaudio==2.8.0.{TORCH_NIGHTLY_VERSION}",

--- a/install_dev.py
+++ b/install_dev.py
@@ -6,9 +6,9 @@ import sys
 def install_torch_nightly_deps():
     """Install torch related dependencies from pinned nightly"""
     EXECUTORCH_NIGHTLY_VERSION = "dev20250625"
-    TORCHAO_NIGHTLY_VERSION = "dev20250620"
+    TORCHAO_NIGHTLY_VERSION = "dev20250710"
     # Torch nightly is aligned with pinned nightly in https://github.com/pytorch/executorch/blob/main/install_requirements.py#L74
-    TORCH_NIGHTLY_VERSION = "dev20250601"
+    TORCH_NIGHTLY_VERSION = "dev20250716"
     subprocess.check_call(
         [
             sys.executable,
@@ -16,8 +16,8 @@ def install_torch_nightly_deps():
             "pip",
             "install",
             f"executorch==0.7.0.{EXECUTORCH_NIGHTLY_VERSION}",
-            f"torch==2.8.0.{TORCH_NIGHTLY_VERSION}",
-            f"torchvision==0.23.0.{TORCH_NIGHTLY_VERSION}",
+            f"torch==2.9.0.{TORCH_NIGHTLY_VERSION}",
+            f"torchvision==0.24.0.{TORCH_NIGHTLY_VERSION}",
             f"torchaudio==2.8.0.{TORCH_NIGHTLY_VERSION}",
             f"torchao==0.12.0.{TORCHAO_NIGHTLY_VERSION}",
             "--extra-index-url",

--- a/install_dev.py
+++ b/install_dev.py
@@ -34,7 +34,7 @@ def install_dep_from_source():
             "-m",
             "pip",
             "install",
-            "git+https://github.com/huggingface/transformers@896e9cea1ade521b2648f4798218550f6c72190c#egg=transformers",  # 4.54.1
+            "git+https://github.com/huggingface/transformers@9c641dc16154964e5ffc0c13e9ec6aaffa295ed6#egg=transformers",  # 4.54.1
         ]
     )
     subprocess.check_call(

--- a/install_dev.py
+++ b/install_dev.py
@@ -6,9 +6,9 @@ import sys
 def install_torch_nightly_deps():
     """Install torch related dependencies from pinned nightly"""
     EXECUTORCH_NIGHTLY_VERSION = "dev20250730"
-    TORCHAO_NIGHTLY_VERSION = "dev20250710"
+    TORCHAO_NIGHTLY_VERSION = "dev20250730"
     # Torch nightly is aligned with pinned nightly in https://github.com/pytorch/executorch/blob/main/install_requirements.py#L74
-    TORCH_NIGHTLY_VERSION = "dev20250716"
+    TORCH_NIGHTLY_VERSION = "dev20250725"
     subprocess.check_call(
         [
             sys.executable,
@@ -19,7 +19,7 @@ def install_torch_nightly_deps():
             f"torch==2.9.0.{TORCH_NIGHTLY_VERSION}",
             f"torchvision==0.24.0.{TORCH_NIGHTLY_VERSION}",
             f"torchaudio==2.8.0.{TORCH_NIGHTLY_VERSION}",
-            f"torchao==0.12.0.{TORCHAO_NIGHTLY_VERSION}",
+            f"torchao==0.13.0.{TORCHAO_NIGHTLY_VERSION}",
             "--extra-index-url",
             "https://download.pytorch.org/whl/nightly/cpu",
         ]

--- a/install_dev.py
+++ b/install_dev.py
@@ -5,7 +5,7 @@ import sys
 
 def install_torch_nightly_deps():
     """Install torch related dependencies from pinned nightly"""
-    EXECUTORCH_NIGHTLY_VERSION = "dev20250730"
+    EXECUTORCH_NIGHTLY_VERSION = "dev20250701"
     TORCHAO_NIGHTLY_VERSION = "dev20250730"
     # Torch nightly is aligned with pinned nightly in https://github.com/pytorch/executorch/blob/main/install_requirements.py#L74
     TORCH_NIGHTLY_VERSION = "dev20250725"

--- a/install_dev.py
+++ b/install_dev.py
@@ -5,7 +5,7 @@ import sys
 
 def install_torch_nightly_deps():
     """Install torch related dependencies from pinned nightly"""
-    EXECUTORCH_NIGHTLY_VERSION = "dev20250701"
+    EXECUTORCH_NIGHTLY_VERSION = "dev20250730"
     TORCHAO_NIGHTLY_VERSION = "dev20250730"
     # Torch nightly is aligned with pinned nightly in https://github.com/pytorch/executorch/blob/main/install_requirements.py#L74
     TORCH_NIGHTLY_VERSION = "dev20250725"

--- a/install_dev.py
+++ b/install_dev.py
@@ -5,7 +5,7 @@ import sys
 
 def install_torch_nightly_deps():
     """Install torch related dependencies from pinned nightly"""
-    EXECUTORCH_NIGHTLY_VERSION = "dev20250626"
+    EXECUTORCH_NIGHTLY_VERSION = "dev20250628"
     TORCHAO_NIGHTLY_VERSION = "dev20250730"
     # Torch nightly is aligned with pinned nightly in https://github.com/pytorch/executorch/blob/main/install_requirements.py#L74
     TORCH_NIGHTLY_VERSION = "dev20250725"

--- a/install_dev.py
+++ b/install_dev.py
@@ -34,7 +34,7 @@ def install_dep_from_source():
             "-m",
             "pip",
             "install",
-            "git+https://github.com/huggingface/transformers@896e9cea1ade521b2648f4798218550f6c72190c#egg=transformers",  # 4.53.1
+            "git+https://github.com/huggingface/transformers@9c641dc16154964e5ffc0c13e9ec6aaffa295ed6#egg=transformers",  # 4.54.1
         ]
     )
     subprocess.check_call(

--- a/install_dev.py
+++ b/install_dev.py
@@ -34,7 +34,7 @@ def install_dep_from_source():
             "-m",
             "pip",
             "install",
-            "git+https://github.com/huggingface/transformers@9c641dc16154964e5ffc0c13e9ec6aaffa295ed6#egg=transformers",  # 4.54.1
+            "git+https://github.com/huggingface/transformers@896e9cea1ade521b2648f4798218550f6c72190c#egg=transformers",  # 4.54.1
         ]
     )
     subprocess.check_call(

--- a/optimum/commands/export/executorch.py
+++ b/optimum/commands/export/executorch.py
@@ -68,6 +68,12 @@ def parse_args_executorch(parser):
         help="For decoder-only models to use custom kv cache for static cache that updates cache using custom op. Defaults to False.",
     )
     required_group.add_argument(
+        "--disable_dynamic_shapes",
+        required=False,
+        action="store_true",
+        help="When this flag is set on decoder-only models, dynamic shapes are disabled during export.",
+    )
+    required_group.add_argument(
         "--qlinear",
         type=str,
         choices=["8da4w", "4w", "8w"],
@@ -109,6 +115,8 @@ class ExecuTorchExportCommand(BaseOptimumCLICommand):
             kwargs["use_custom_sdpa"] = self.args.use_custom_sdpa
         if self.args.use_custom_kv_cache:
             kwargs["use_custom_kv_cache"] = self.args.use_custom_kv_cache
+        if self.args.disable_dynamic_shapes:
+            kwargs["disable_dynamic_shapes"] = self.args.disable_dynamic_shapes
         if self.args.qlinear:
             kwargs["qlinear"] = self.args.qlinear
         if self.args.qembedding:

--- a/optimum/commands/export/executorch.py
+++ b/optimum/commands/export/executorch.py
@@ -69,15 +69,28 @@ def parse_args_executorch(parser):
     )
     required_group.add_argument(
         "--qlinear",
+        type=str,
+        choices=["8da4w", "4w", "8w"],
         required=False,
-        action="store_true",
-        help="Quantization config for linear layers. If set, defaults to '8da4w' w/ groupsize 32.",
+        help=(
+            "Quantization config for linear layers.\n\n"
+            "Options:\n"
+            "  8da4w - 8-bit dynamic activation, 4-bit weight with group_size = 32\n"
+            "  4w    - 4-bit weight only, per group with group_size = 32\n"
+            "  8w    - 8-bit weight only, per channel"
+        ),
     )
     required_group.add_argument(
         "--qembedding",
+        type=str,
+        choices=["4w", "8w"],
         required=False,
-        action="store_true",
-        help="Quantization config for embedding. If set, defaults to int8 channelwise.",
+        help=(
+            "Quantization config for embedding layer.\n\n"
+            "Options:\n"
+            "  4w    - 4-bit weight only, per group with group_size = 32\n"
+            "  8w    - 8-bit weight only, per channel"
+        ),
     )
 
 

--- a/optimum/executorch/attentions/custom_kv_cache.py
+++ b/optimum/executorch/attentions/custom_kv_cache.py
@@ -210,7 +210,7 @@ class ETCustomHybridCache(HybridCache):
         # Use CustomKVCache for global layers and CustomRingKVCache for sliding window layers.
         self.kv_cache = torch.nn.ModuleList()
         for layer in self.layers:
-            if layer.is_sliding():
+            if layer.is_sliding:
                 # This is a sliding window layer
                 layer_cache = CustomRingKVCache(
                     max_batch_size=layer.max_batch_size,
@@ -281,7 +281,7 @@ class ETCustomHybridCache(HybridCache):
 
         # For CustomRingKVCache, we need to handle the sequence length differently
         layer_cache = self.kv_cache[layer_idx]
-        if self.layers[layer_idx].is_sliding():
+        if self.layers[layer_idx].is_sliding:
             # CustomRingKVCache cache_position_manager which
             # maintains cache position for each slot in the kv cache
             # we return the max position + 1 to indicate max position
@@ -385,7 +385,7 @@ def _replace_with_et_custom_kv_cache(module, config, generation_config, cache_dt
             for i in range(len(module.cache.kv_cache)):
                 setattr(module, f"key_cache_{i}", module.cache.kv_cache[i].k_cache)
                 setattr(module, f"value_cache_{i}", module.cache.kv_cache[i].v_cache)
-                if module.cache.layers[i].is_sliding():
+                if module.cache.layers[i].is_sliding:
                     # Register cache_positions as buffer for sliding window layers
                     # This prevents it from being traced as a constant
                     module.register_buffer(

--- a/optimum/executorch/attentions/custom_kv_cache.py
+++ b/optimum/executorch/attentions/custom_kv_cache.py
@@ -54,12 +54,12 @@ class ETCustomStaticCache(StaticCache):
 
         # Create a list of CustomKVCache instances, one per layer
         self.kv_cache = torch.nn.ModuleList()
-        for _ in range(config.num_hidden_layers):
+        for layer in self.layers:
             layer_cache = CustomKVCache(
-                max_batch_size=self.max_batch_size,
-                max_context_length=self.max_cache_len,
-                n_heads=self.num_key_value_heads,
-                head_dim=self.head_dim,
+                max_batch_size=layer.max_batch_size,
+                max_context_length=layer.max_cache_len,
+                n_heads=layer.num_heads,
+                head_dim=layer.head_dim,
                 dtype=dtype,
             )
             self.kv_cache.append(layer_cache)
@@ -202,32 +202,29 @@ class ETCustomHybridCache(HybridCache):
             layer_device_map=layer_device_map,
         )
 
-        # make sure layer_device_map is none
         assert layer_device_map is None
         assert device is None or device == "cpu", "Device must be None or 'cpu'"
 
         self.cache_position = None
-        # Create a list of cache instances, one per layer
-        # Use CustomKVCache for global layers and CustomRingKVCache for sliding window layers
+        # Create a list of cache instances, one per layer.
+        # Use CustomKVCache for global layers and CustomRingKVCache for sliding window layers.
         self.kv_cache = torch.nn.ModuleList()
-        for layer_idx in range(config.num_hidden_layers):
-            # newer version of transfomer has is_sliding defined
-            # for HybridCache
-            if self.is_sliding[layer_idx]:
+        for layer in self.layers:
+            if layer.is_sliding():
                 # This is a sliding window layer
                 layer_cache = CustomRingKVCache(
-                    max_batch_size=self.max_batch_size,
-                    max_context_length=self.sliding_window_len,
-                    n_heads=self.num_key_value_heads,
-                    head_dim=self.head_dim,
+                    max_batch_size=layer.max_batch_size,
+                    max_context_length=layer.max_cache_len,
+                    n_heads=layer.num_heads,
+                    head_dim=layer.head_dim,
                     dtype=dtype,
                 )
             else:
                 layer_cache = CustomKVCache(
-                    max_batch_size=self.max_batch_size,
-                    max_context_length=self.max_cache_len,
-                    n_heads=self.num_key_value_heads,
-                    head_dim=self.head_dim,
+                    max_batch_size=layer.max_batch_size,
+                    max_context_length=layer.max_cache_len,
+                    n_heads=layer.num_heads,
+                    head_dim=layer.head_dim,
                     dtype=dtype,
                 )
             self.kv_cache.append(layer_cache)
@@ -284,7 +281,7 @@ class ETCustomHybridCache(HybridCache):
 
         # For CustomRingKVCache, we need to handle the sequence length differently
         layer_cache = self.kv_cache[layer_idx]
-        if self.is_sliding[layer_idx]:
+        if self.layers[layer_idx].is_sliding():
             # CustomRingKVCache cache_position_manager which
             # maintains cache position for each slot in the kv cache
             # we return the max position + 1 to indicate max position
@@ -308,7 +305,7 @@ class ETCustomHybridCache(HybridCache):
 
 def replace_with_et_custom_kv_cache(module, config, generation_config, cache_dtype):
     """
-    Replace all KV caches in the module with ETCustomStaticCache.
+    Replace all KV caches in the module with ETCustomStaticCache or ETCustomHybridCache.
     This modifies the model in place.
 
     Args:
@@ -342,18 +339,18 @@ def _replace_with_et_custom_kv_cache(module, config, generation_config, cache_dt
         if getattr(module, "replace_cache", None) is not None:
             static_cache = ETCustomStaticCache(
                 config=config,
-                max_batch_size=generation_config.cache_config.batch_size,
-                max_cache_len=generation_config.cache_config.max_cache_len,
-                device=generation_config.cache_config.device,
+                max_batch_size=generation_config.cache_config.get("batch_size"),
+                max_cache_len=generation_config.cache_config.get("max_cache_len"),
+                device=generation_config.cache_config.get("device"),
                 dtype=cache_dtype,
             )
             module.replace_cache(static_cache)
         else:
             module.static_cache = ETCustomStaticCache(
                 config=config,
-                max_batch_size=generation_config.cache_config.batch_size,
-                max_cache_len=generation_config.cache_config.max_cache_len,
-                device=generation_config.cache_config.device,
+                max_batch_size=generation_config.cache_config.get("batch_size"),
+                max_cache_len=generation_config.cache_config.get("max_cache_len"),
+                device=generation_config.cache_config.get("device"),
                 dtype=cache_dtype,
             )
             # Dont know why we need to this even though
@@ -370,25 +367,25 @@ def _replace_with_et_custom_kv_cache(module, config, generation_config, cache_dt
         if getattr(module, "replace_cache", None) is not None:
             hybrid_cache = ETCustomHybridCache(
                 config=config,
-                max_batch_size=generation_config.cache_config.batch_size,
-                max_cache_len=generation_config.cache_config.max_cache_len,
-                device=generation_config.cache_config.device,
+                max_batch_size=generation_config.cache_config.get("batch_size"),
+                max_cache_len=generation_config.cache_config.get("max_cache_len"),
+                device=generation_config.cache_config.get("device"),
                 dtype=cache_dtype,
             )
             module.replace_cache(hybrid_cache)
         else:
             module.cache = ETCustomHybridCache(
                 config=config,
-                max_batch_size=generation_config.cache_config.batch_size,
-                max_cache_len=generation_config.cache_config.max_cache_len,
-                device=generation_config.cache_config.device,
+                max_batch_size=generation_config.cache_config.get("batch_size"),
+                max_cache_len=generation_config.cache_config.get("max_cache_len"),
+                device=generation_config.cache_config.get("device"),
                 dtype=cache_dtype,
             )
             # Register cache attributes for each layer
             for i in range(len(module.cache.kv_cache)):
                 setattr(module, f"key_cache_{i}", module.cache.kv_cache[i].k_cache)
                 setattr(module, f"value_cache_{i}", module.cache.kv_cache[i].v_cache)
-                if module.cache.is_sliding[i]:
+                if module.cache.layers[i].is_sliding():
                     # Register cache_positions as buffer for sliding window layers
                     # This prevents it from being traced as a constant
                     module.register_buffer(

--- a/optimum/executorch/attentions/custom_kv_cache.py
+++ b/optimum/executorch/attentions/custom_kv_cache.py
@@ -54,12 +54,12 @@ class ETCustomStaticCache(StaticCache):
 
         # Create a list of CustomKVCache instances, one per layer
         self.kv_cache = torch.nn.ModuleList()
-        for layer in self.layers:
+        for _ in range(config.num_hidden_layers):
             layer_cache = CustomKVCache(
-                max_batch_size=layer.max_batch_size,
-                max_context_length=layer.max_cache_len,
-                n_heads=layer.num_heads,
-                head_dim=layer.head_dim,
+                max_batch_size=self.max_batch_size,
+                max_context_length=self.max_cache_len,
+                n_heads=self.num_key_value_heads,
+                head_dim=self.head_dim,
                 dtype=dtype,
             )
             self.kv_cache.append(layer_cache)
@@ -202,29 +202,32 @@ class ETCustomHybridCache(HybridCache):
             layer_device_map=layer_device_map,
         )
 
+        # make sure layer_device_map is none
         assert layer_device_map is None
         assert device is None or device == "cpu", "Device must be None or 'cpu'"
 
         self.cache_position = None
-        # Create a list of cache instances, one per layer.
-        # Use CustomKVCache for global layers and CustomRingKVCache for sliding window layers.
+        # Create a list of cache instances, one per layer
+        # Use CustomKVCache for global layers and CustomRingKVCache for sliding window layers
         self.kv_cache = torch.nn.ModuleList()
-        for layer in self.layers:
-            if layer.is_sliding:
+        for layer_idx in range(config.num_hidden_layers):
+            # newer version of transfomer has is_sliding defined
+            # for HybridCache
+            if self.is_sliding[layer_idx]:
                 # This is a sliding window layer
                 layer_cache = CustomRingKVCache(
-                    max_batch_size=layer.max_batch_size,
-                    max_context_length=layer.max_cache_len,
-                    n_heads=layer.num_heads,
-                    head_dim=layer.head_dim,
+                    max_batch_size=self.max_batch_size,
+                    max_context_length=self.sliding_window_len,
+                    n_heads=self.num_key_value_heads,
+                    head_dim=self.head_dim,
                     dtype=dtype,
                 )
             else:
                 layer_cache = CustomKVCache(
-                    max_batch_size=layer.max_batch_size,
-                    max_context_length=layer.max_cache_len,
-                    n_heads=layer.num_heads,
-                    head_dim=layer.head_dim,
+                    max_batch_size=self.max_batch_size,
+                    max_context_length=self.max_cache_len,
+                    n_heads=self.num_key_value_heads,
+                    head_dim=self.head_dim,
                     dtype=dtype,
                 )
             self.kv_cache.append(layer_cache)
@@ -281,7 +284,7 @@ class ETCustomHybridCache(HybridCache):
 
         # For CustomRingKVCache, we need to handle the sequence length differently
         layer_cache = self.kv_cache[layer_idx]
-        if self.layers[layer_idx].is_sliding:
+        if self.is_sliding[layer_idx]:
             # CustomRingKVCache cache_position_manager which
             # maintains cache position for each slot in the kv cache
             # we return the max position + 1 to indicate max position
@@ -305,7 +308,7 @@ class ETCustomHybridCache(HybridCache):
 
 def replace_with_et_custom_kv_cache(module, config, generation_config, cache_dtype):
     """
-    Replace all KV caches in the module with ETCustomStaticCache or ETCustomHybridCache.
+    Replace all KV caches in the module with ETCustomStaticCache.
     This modifies the model in place.
 
     Args:
@@ -339,18 +342,18 @@ def _replace_with_et_custom_kv_cache(module, config, generation_config, cache_dt
         if getattr(module, "replace_cache", None) is not None:
             static_cache = ETCustomStaticCache(
                 config=config,
-                max_batch_size=generation_config.cache_config.get("batch_size"),
-                max_cache_len=generation_config.cache_config.get("max_cache_len"),
-                device=generation_config.cache_config.get("device"),
+                max_batch_size=generation_config.cache_config.batch_size,
+                max_cache_len=generation_config.cache_config.max_cache_len,
+                device=generation_config.cache_config.device,
                 dtype=cache_dtype,
             )
             module.replace_cache(static_cache)
         else:
             module.static_cache = ETCustomStaticCache(
                 config=config,
-                max_batch_size=generation_config.cache_config.get("batch_size"),
-                max_cache_len=generation_config.cache_config.get("max_cache_len"),
-                device=generation_config.cache_config.get("device"),
+                max_batch_size=generation_config.cache_config.batch_size,
+                max_cache_len=generation_config.cache_config.max_cache_len,
+                device=generation_config.cache_config.device,
                 dtype=cache_dtype,
             )
             # Dont know why we need to this even though
@@ -367,25 +370,25 @@ def _replace_with_et_custom_kv_cache(module, config, generation_config, cache_dt
         if getattr(module, "replace_cache", None) is not None:
             hybrid_cache = ETCustomHybridCache(
                 config=config,
-                max_batch_size=generation_config.cache_config.get("batch_size"),
-                max_cache_len=generation_config.cache_config.get("max_cache_len"),
-                device=generation_config.cache_config.get("device"),
+                max_batch_size=generation_config.cache_config.batch_size,
+                max_cache_len=generation_config.cache_config.max_cache_len,
+                device=generation_config.cache_config.device,
                 dtype=cache_dtype,
             )
             module.replace_cache(hybrid_cache)
         else:
             module.cache = ETCustomHybridCache(
                 config=config,
-                max_batch_size=generation_config.cache_config.get("batch_size"),
-                max_cache_len=generation_config.cache_config.get("max_cache_len"),
-                device=generation_config.cache_config.get("device"),
+                max_batch_size=generation_config.cache_config.batch_size,
+                max_cache_len=generation_config.cache_config.max_cache_len,
+                device=generation_config.cache_config.device,
                 dtype=cache_dtype,
             )
             # Register cache attributes for each layer
             for i in range(len(module.cache.kv_cache)):
                 setattr(module, f"key_cache_{i}", module.cache.kv_cache[i].k_cache)
                 setattr(module, f"value_cache_{i}", module.cache.kv_cache[i].v_cache)
-                if module.cache.layers[i].is_sliding:
+                if module.cache.is_sliding[i]:
                     # Register cache_positions as buffer for sliding window layers
                     # This prevents it from being traced as a constant
                     module.register_buffer(

--- a/optimum/executorch/modeling.py
+++ b/optimum/executorch/modeling.py
@@ -186,6 +186,13 @@ class ExecuTorchModelBase(OptimizedModel, ABC):
             subfolder=subfolder,
             local_files_only=local_files_only,
         )
+
+        from torch.ao.quantization.fx._decomposed import quantized_decomposed_lib  # noqa
+        from executorch.kernels import quantized  # noqa
+        from executorch.extension.pybindings.portable_lib import _get_operator_names
+        print("----------- LOADED OPS ----------")
+        print('\n'.join(_get_operator_names()))
+        print("---------------------------------")
         model = _load_for_executorch(model_cache_path)
         logging.info(
             f"Loaded model from {model_cache_path} ({os.path.getsize(model_cache_path) / (1024 * 1024):.2f} MB)"

--- a/optimum/executorch/modeling.py
+++ b/optimum/executorch/modeling.py
@@ -217,6 +217,9 @@ class ExecuTorchModelBase(OptimizedModel, ABC):
             local_files_only=local_files_only,
         )
         model = _load_for_executorch(model_cache_path)
+        logging.info(
+            f"Loaded model from {model_cache_path} ({os.path.getsize(model_cache_path) / (1024 * 1024):.2f} MB)"
+        )
 
         return {default_file_name.removesuffix(_PTE_SUFFIX): model}
 

--- a/optimum/executorch/modeling.py
+++ b/optimum/executorch/modeling.py
@@ -104,19 +104,19 @@ class ExecuTorchModelBase(OptimizedModel, ABC):
                 setattr(self, key, value)
 
         self.stats = Stats()
-        
+
         # Initialize cleanup tracking
         self._temp_dir = None
 
     def __del__(self):
         """Clean up temporary files when the model instance is destroyed."""
         self._cleanup_temp_resources()
-    
+
     def _cleanup_temp_resources(self):
         """Clean up temporary directory and files."""
-        if hasattr(self, '_temp_dir') and self._temp_dir is not None:
+        if hasattr(self, "_temp_dir") and self._temp_dir is not None:
             try:
-                if hasattr(self._temp_dir, 'cleanup'):
+                if hasattr(self._temp_dir, "cleanup"):
                     # It's a TemporaryDirectory object
                     logging.info(f"Cleaning up temporary directory: {self._temp_dir.name}")
                     self._temp_dir.cleanup()
@@ -216,17 +216,7 @@ class ExecuTorchModelBase(OptimizedModel, ABC):
             subfolder=subfolder,
             local_files_only=local_files_only,
         )
-
-        from torch.ao.quantization.fx._decomposed import quantized_decomposed_lib  # noqa
-        from executorch.kernels import quantized  # noqa
-        from executorch.extension.pybindings.portable_lib import _get_operator_names
-        print("----------- LOADED OPS ----------")
-        print('\n'.join(_get_operator_names()))
-        print("---------------------------------")
         model = _load_for_executorch(model_cache_path)
-        logging.info(
-            f"Loaded model from {model_cache_path} ({os.path.getsize(model_cache_path) / (1024 * 1024):.2f} MB)"
-        )
 
         return {default_file_name.removesuffix(_PTE_SUFFIX): model}
 
@@ -304,15 +294,6 @@ class ExecuTorchModelBase(OptimizedModel, ABC):
         for name, _ in executorch_progs.items():
             models.update(cls._from_pretrained(save_dir_path, file_name=f"{name}.pte", config=config))
 
-        # Log temp directory info for debugging
-        logging.info(f"Created temporary directory: {save_dir_path}")
-        for name in executorch_progs.keys():
-            pte_file = save_dir_path / f"{name}.pte"
-            if pte_file.exists():
-                logging.info(f"PTE file exists at export: {pte_file} (size: {pte_file.stat().st_size} bytes)")
-            else:
-                logging.warning(f"PTE file missing at export: {pte_file}")
-        
         return models, save_dir
 
     def _save_pretrained(self, save_directory):
@@ -399,7 +380,9 @@ class ExecuTorchModelBase(OptimizedModel, ABC):
                 **kwargs,
             )
         else:
-            logging.info(f"Pre-exported `.pte` artifact already exists in HuggingFace repo or provided file path for {model_id}, skipping export.")
+            logging.info(
+                f"Pre-exported `.pte` artifact already exists in HuggingFace repo or provided file path for {model_id}, skipping export."
+            )
             models_dict = {}
             for pte_file in pte_files:
                 models_dict.update(
@@ -418,12 +401,12 @@ class ExecuTorchModelBase(OptimizedModel, ABC):
                 )
 
         model_instance = cls(models_dict, config)
-        
+
         # Store the TemporaryDirectory reference to prevent GC
         if temp_dir is not None:
             model_instance._temp_dir = temp_dir
             logging.info(f"Stored temp directory reference in model: {temp_dir.name}")
-            
+
         return model_instance
 
 
@@ -695,32 +678,12 @@ class ExecuTorchModelForCausalLM(ExecuTorchModelBase):
         Returns:
             torch.Tensor: Logits output from the model.
         """
-        # Check if temp directory and PTE file still exist before forward pass
-        if hasattr(self, '_temp_dir') and self._temp_dir is not None:
-            temp_path = Path(self._temp_dir.name)
-            logging.info(f"Forward pass - temp directory exists: {temp_path.exists()}")
-            if temp_path.exists():
-                pte_files = list(temp_path.glob("*.pte"))
-                logging.info(f"Forward pass - PTE files found: {len(pte_files)}")
-                for pte_file in pte_files:
-                    logging.info(f"Forward pass - PTE file: {pte_file} exists: {pte_file.exists()}, size: {pte_file.stat().st_size if pte_file.exists() else 'N/A'}")
-            else:
-                logging.error(f"Forward pass - temp directory missing: {temp_path}")
-        else:
-            logging.info("Forward pass - no temp directory reference stored")
-
         self.stats.on_model_execution_start()
 
         try:
-            logging.info("Running forward()...")
             logits = self.model.forward((input_ids, cache_position))[0]
-            logging.info(f"logits from forward(): {logits}")
         except Exception as e:
             shapes = {name: val.shape for name, val in locals().items() if hasattr(val, "shape")}
-            logging.error(f"Forward pass failed - temp dir exists: {hasattr(self, '_temp_dir') and self._temp_dir is not None}")
-            if hasattr(self, '_temp_dir') and self._temp_dir is not None:
-                temp_path = Path(self._temp_dir.name)
-                logging.error(f"Forward pass failed - temp directory: {temp_path} exists: {temp_path.exists()}")
             print(f"Exception: {e}.\n{self.model.method_meta('forward')}\narg shapes: {shapes}")
             raise
 

--- a/optimum/executorch/modeling.py
+++ b/optimum/executorch/modeling.py
@@ -16,7 +16,6 @@
 
 import logging
 import os
-import tempfile
 import shutil
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -120,12 +119,12 @@ class ExecuTorchModelBase(OptimizedModel, ABC):
                     # It's a TemporaryDirectory object
                     logging.info(f"Cleaning up temporary directory: {self._temp_dir.name}")
                     self._temp_dir.cleanup()
-                    logging.info(f"Temporary directory cleanup completed")
+                    logging.info("Temporary directory cleanup completed")
                 elif isinstance(self._temp_dir, (str, Path)):
                     # It's a path
                     logging.info(f"Cleaning up temporary path: {self._temp_dir}")
                     shutil.rmtree(self._temp_dir, ignore_errors=True)
-                    logging.info(f"Temporary path cleanup completed")
+                    logging.info("Temporary path cleanup completed")
             except Exception as e:
                 # Log cleanup errors for debugging
                 logging.warning(f"Error during temp directory cleanup: {e}")

--- a/optimum/executorch/modeling.py
+++ b/optimum/executorch/modeling.py
@@ -16,6 +16,7 @@
 
 import logging
 import os
+import shutil
 from abc import ABC, abstractmethod
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -24,6 +25,7 @@ from typing import Dict, List, Optional, Union
 import torch
 from huggingface_hub import hf_hub_download
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
+from torch.ao.quantization.fx._decomposed import quantized_decomposed_lib  # noqa
 from transformers import (
     AutoModelForCausalLM,
     AutoModelForImageClassification,
@@ -101,6 +103,34 @@ class ExecuTorchModelBase(OptimizedModel, ABC):
                 setattr(self, key, value)
 
         self.stats = Stats()
+
+        # Initialize cleanup tracking
+        self._temp_dir = None
+
+    def __del__(self):
+        """Clean up temporary files when the model instance is destroyed."""
+        self._cleanup_temp_resources()
+
+    def _cleanup_temp_resources(self):
+        """Clean up temporary directory and files."""
+        if hasattr(self, "_temp_dir") and self._temp_dir is not None:
+            try:
+                if hasattr(self._temp_dir, "cleanup"):
+                    # It's a TemporaryDirectory object
+                    logging.info(f"Cleaning up temporary directory: {self._temp_dir.name}")
+                    self._temp_dir.cleanup()
+                    logging.info("Temporary directory cleanup completed")
+                elif isinstance(self._temp_dir, (str, Path)):
+                    # It's a path
+                    logging.info(f"Cleaning up temporary path: {self._temp_dir}")
+                    shutil.rmtree(self._temp_dir, ignore_errors=True)
+                    logging.info("Temporary path cleanup completed")
+            except Exception as e:
+                # Log cleanup errors for debugging
+                logging.warning(f"Error during temp directory cleanup: {e}")
+                pass
+            finally:
+                self._temp_dir = None
 
     @abstractmethod
     def forward(self, *args, **kwargs):
@@ -242,7 +272,7 @@ class ExecuTorchModelBase(OptimizedModel, ABC):
         inferred_task = TasksManager.infer_task_from_model(cls.auto_model_class)
         logging.info(f"Inferred task from model class: {inferred_task}")
 
-        save_dir = TemporaryDirectory()
+        save_dir = TemporaryDirectory(prefix="executorch_export_")
         save_dir_path = Path(save_dir.name)
 
         # Export to ExecuTorch and save the pte file to the temporary directory
@@ -266,7 +296,7 @@ class ExecuTorchModelBase(OptimizedModel, ABC):
         for name, _ in executorch_progs.items():
             models.update(cls._from_pretrained(save_dir_path, file_name=f"{name}.pte", config=config))
 
-        return models
+        return models, save_dir
 
     def _save_pretrained(self, save_directory):
         """
@@ -298,6 +328,7 @@ class ExecuTorchModelBase(OptimizedModel, ABC):
             logger.info("Offline mode: setting `local_files_only=True`")
             local_files_only = True
 
+        # See if model was already exported to ExecuTorch and uplaoded to the HuggingFace repo.
         _export = export
         try:
             if local_files_only and not os.path.isdir(model_id):
@@ -324,21 +355,21 @@ class ExecuTorchModelBase(OptimizedModel, ABC):
                 if export:
                     logger.warning(
                         f"The model {model_id} was already converted to the ExecuTorch IR but got `export=True`, the model will be converted to ExecuTorch once again. "
-                        # "Don't forget to save the resulting model with `.save_pretrained()`"
                     )
                     _export = True
                 else:
                     logger.warning(
                         f"No ExecuTorch files were found for {model_id}, setting `export=True` to convert the model to the ExecuTorch IR. "
-                        # "Don't forget to save the resulting model with `.save_pretrained()`"
                     )
         except Exception as exception:
             logger.warning(
                 f"Could not infer whether the model was already converted or not to the ExecuTorch IR, keeping `export={export}`.\n{exception}"
             )
 
+        temp_dir = None
         if _export:
-            models_dict = cls._export(
+            logging.info(f"Exporting {model_id} to ExecuTorch program...")
+            models_dict, temp_dir = cls._export(
                 model_id=model_id,
                 config=config,
                 revision=revision,
@@ -351,6 +382,9 @@ class ExecuTorchModelBase(OptimizedModel, ABC):
                 **kwargs,
             )
         else:
+            logging.info(
+                f"Pre-exported `.pte` artifact already exists in HuggingFace repo or provided file path for {model_id}, skipping export."
+            )
             models_dict = {}
             for pte_file in pte_files:
                 models_dict.update(
@@ -368,7 +402,14 @@ class ExecuTorchModelBase(OptimizedModel, ABC):
                     )
                 )
 
-        return cls(models_dict, config)
+        model_instance = cls(models_dict, config)
+
+        # Store the TemporaryDirectory reference to prevent GC
+        if temp_dir is not None:
+            model_instance._temp_dir = temp_dir
+            logging.info(f"Stored temp directory reference in model: {temp_dir.name}")
+
+        return model_instance
 
 
 class ExecuTorchModelForSeq2SeqLM(ExecuTorchModelBase):

--- a/optimum/executorch/modeling.py
+++ b/optimum/executorch/modeling.py
@@ -24,6 +24,7 @@ from typing import Dict, List, Optional, Union
 import torch
 from huggingface_hub import hf_hub_download
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
+from torch.ao.quantization.fx._decomposed import quantized_decomposed_lib  # noqa
 from transformers import (
     AutoModelForCausalLM,
     AutoModelForImageClassification,

--- a/optimum/exporters/executorch/__main__.py
+++ b/optimum/exporters/executorch/__main__.py
@@ -15,6 +15,7 @@
 """Entry point to the optimum.exporters.executorch command line."""
 
 import argparse
+import logging
 import os
 import warnings
 from pathlib import Path
@@ -130,13 +131,15 @@ def main_export(
     kwargs["force_download"] = force_download
     kwargs["config"] = config
 
+    # 1. Load model, apply source transformations, and torch.export() into a graph (ExportedProgram).
+    logging.info(f"Loading {model_name_or_path} and exporting to static graph...")
     recipe_kwargs = kwargs.pop("recipe_kwargs", {})
-
     model = task_func(model_name_or_path, **kwargs)
 
+    # 2. Export to ExecuTorch through ExecuTorch's lowering APIs.
+    logging.info(f"Lowering {model_name_or_path} to ExecuTorch...")
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
-
     return export_to_executorch(
         model=model,
         task=task,

--- a/optimum/exporters/executorch/__main__.py
+++ b/optimum/exporters/executorch/__main__.py
@@ -134,12 +134,14 @@ def main_export(
     # 1. Load model, apply source transformations, and torch.export() into a graph (ExportedProgram).
     logging.info(f"Loading {model_name_or_path} and exporting to static graph...")
     recipe_kwargs = kwargs.pop("recipe_kwargs", {})
+
     model = task_func(model_name_or_path, **kwargs)
 
     # 2. Export to ExecuTorch through ExecuTorch's lowering APIs.
     logging.info(f"Lowering {model_name_or_path} to ExecuTorch...")
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
+
     return export_to_executorch(
         model=model,
         task=task,

--- a/optimum/exporters/executorch/__main__.py
+++ b/optimum/exporters/executorch/__main__.py
@@ -15,6 +15,7 @@
 """Entry point to the optimum.exporters.executorch command line."""
 
 import argparse
+import logging
 import os
 import warnings
 from pathlib import Path
@@ -130,10 +131,14 @@ def main_export(
     kwargs["force_download"] = force_download
     kwargs["config"] = config
 
+    # 1. Load model, apply source transformations, and torch.export() into a graph (ExportedProgram).
+    logging.info(f"Loading {model_name_or_path} and exporting to static graph...")
     recipe_kwargs = kwargs.pop("recipe_kwargs", {})
 
     model = task_func(model_name_or_path, **kwargs)
 
+    # 2. Export to ExecuTorch through ExecuTorch's lowering APIs.
+    logging.info(f"Lowering {model_name_or_path} to ExecuTorch...")
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
 

--- a/optimum/exporters/executorch/convert.py
+++ b/optimum/exporters/executorch/convert.py
@@ -19,20 +19,17 @@ import os
 from pathlib import Path
 from typing import Union
 
+from transformers.integrations.executorch import sdpa_mask_without_vmap
+from transformers.masking_utils import AttentionMaskInterface
 from transformers.modeling_utils import AttentionInterface
 
 from optimum.executorch.attentions.custom_sdpa import custom_sdpa_with_start_pos_forward
-from optimum.utils.import_utils import is_transformers_version
 
 from .recipe_registry import discover_recipes, recipe_registry
 
 
 AttentionInterface.register("custom_sdpa", custom_sdpa_with_start_pos_forward)
-if is_transformers_version(">=", "4.53.0.dev0"):
-    from transformers.integrations.executorch import sdpa_mask_without_vmap
-    from transformers.masking_utils import AttentionMaskInterface
-
-    AttentionMaskInterface.register("custom_sdpa", sdpa_mask_without_vmap)
+AttentionMaskInterface.register("custom_sdpa", sdpa_mask_without_vmap)
 
 
 def export_to_executorch(

--- a/optimum/exporters/executorch/integrations.py
+++ b/optimum/exporters/executorch/integrations.py
@@ -395,8 +395,8 @@ class Seq2SeqLMExportableModule(torch.nn.Module):
         wrapped_decoder = (
             Seq2SeqLMDecoderExportableModuleWithStaticCache(
                 model=self.full_model,
-                max_static_cache_length=self.generation_config.cache_config.max_cache_len,
-                batch_size=self.generation_config.cache_config.batch_size,
+                max_static_cache_length=self.generation_config.cache_config.get("max_cache_len"),
+                batch_size=self.generation_config.cache_config.get("batch_size"),
             )
             .to("cpu")
             .eval()

--- a/optimum/exporters/executorch/integrations.py
+++ b/optimum/exporters/executorch/integrations.py
@@ -399,8 +399,8 @@ class Seq2SeqLMExportableModule(torch.nn.Module):
         wrapped_decoder = (
             Seq2SeqLMDecoderExportableModuleWithStaticCache(
                 model=self.full_model,
-                max_static_cache_length=self.generation_config.cache_config.get("max_cache_len"),
-                batch_size=self.generation_config.cache_config.get("batch_size"),
+                max_static_cache_length=self.generation_config.cache_config.max_cache_len,
+                batch_size=self.generation_config.cache_config.batch_size,
             )
             .to("cpu")
             .eval()

--- a/optimum/exporters/executorch/integrations.py
+++ b/optimum/exporters/executorch/integrations.py
@@ -28,7 +28,6 @@ from transformers import (
 )
 from transformers.generation.configuration_utils import GenerationConfig
 
-from executorch import version as executorch_version
 from optimum.executorch.attentions.custom_sdpa import get_custom_sdpa_for_ring_kv_cache
 from optimum.utils.import_utils import is_transformers_version
 

--- a/optimum/exporters/executorch/integrations.py
+++ b/optimum/exporters/executorch/integrations.py
@@ -90,10 +90,7 @@ class CausalLMExportableModule(torch.nn.Module):
         return example_input_ids, example_cache_position, dynamic_shapes, strict
 
     def _register_attention_mask_for_4_53(self, exportable_module: torch.nn.Module):
-        if (
-            is_transformers_version(">=", "4.53.0.dev0")
-            and parse(executorch_version.__version__).base_version > "0.6.0"
-        ):
+        if is_transformers_version(">=", "4.53.0.dev0"):
             from transformers.integrations.executorch import sdpa_mask_without_vmap
             from transformers.masking_utils import AttentionMaskInterface
             from transformers.modeling_utils import AttentionInterface
@@ -130,7 +127,7 @@ class CausalLMExportableModule(torch.nn.Module):
             )
             self._register_attention_mask_for_4_53(exportable_module)
 
-            if self.use_custom_kv_cache and parse(executorch_version.__version__).base_version > "0.6.0":
+            if self.use_custom_kv_cache:
                 from optimum.executorch.attentions.custom_kv_cache import (
                     replace_with_et_custom_kv_cache,
                 )

--- a/optimum/exporters/executorch/integrations.py
+++ b/optimum/exporters/executorch/integrations.py
@@ -40,12 +40,13 @@ class CausalLMExportableModule(torch.nn.Module):
     This module ensures that the exported model is compatible with ExecuTorch.
     """
 
-    def __init__(self, model, use_custom_kv_cache=False, use_custom_sdpa=False):
+    def __init__(self, model, use_custom_kv_cache=False, use_custom_sdpa=False, disable_dynamic_shapes=False):
         super().__init__()
         self.model = model
         self.config = model.config
         self.use_custom_kv_cache = use_custom_kv_cache
         self.use_custom_sdpa = use_custom_sdpa
+        self.disable_dynamic_shapes = disable_dynamic_shapes
         self.metadata = save_config_to_constant_methods(model.config, model.generation_config)
         logging.info(f"Metadata to be recorded in PTE: {self.metadata}")
 
@@ -71,7 +72,11 @@ class CausalLMExportableModule(torch.nn.Module):
             and not (self.use_custom_kv_cache and self.use_custom_sdpa)
         )
 
-        if is_transformers_version(">", "4.52.0") and not is_using_hybrid_cache_wo_custom_sdpa_kv_cache:
+        if (
+            not self.disable_dynamic_shapes
+            and is_transformers_version(">", "4.52.0")
+            and not is_using_hybrid_cache_wo_custom_sdpa_kv_cache
+        ):
             # Prepare inputs with dynamic shapes
             seq_length = 3  # Sequence length > 1 to avoid specialization issues
             example_input_ids = torch.zeros((1, seq_length), dtype=torch.long)

--- a/optimum/exporters/executorch/integrations.py
+++ b/optimum/exporters/executorch/integrations.py
@@ -29,7 +29,6 @@ from transformers import (
 from transformers.generation.configuration_utils import GenerationConfig
 
 from optimum.executorch.attentions.custom_sdpa import get_custom_sdpa_for_ring_kv_cache
-from optimum.utils.import_utils import is_transformers_version
 
 from .utils import save_config_to_constant_methods
 
@@ -71,7 +70,7 @@ class CausalLMExportableModule(torch.nn.Module):
             and not (self.use_custom_kv_cache and self.use_custom_sdpa)
         )
 
-        if is_transformers_version(">", "4.52.0") and not is_using_hybrid_cache_wo_custom_sdpa_kv_cache:
+        if not is_using_hybrid_cache_wo_custom_sdpa_kv_cache:
             # Prepare inputs with dynamic shapes
             seq_length = 3  # Sequence length > 1 to avoid specialization issues
             example_input_ids = torch.zeros((1, seq_length), dtype=torch.long)
@@ -88,24 +87,23 @@ class CausalLMExportableModule(torch.nn.Module):
 
         return example_input_ids, example_cache_position, dynamic_shapes, strict
 
-    def _register_attention_mask_for_4_53(self, exportable_module: torch.nn.Module):
-        if is_transformers_version(">=", "4.53.0.dev0"):
-            from transformers.integrations.executorch import sdpa_mask_without_vmap
-            from transformers.masking_utils import AttentionMaskInterface
-            from transformers.modeling_utils import AttentionInterface
+    def _register_custom_attention(self, exportable_module: torch.nn.Module):
+        from transformers.integrations.executorch import sdpa_mask_without_vmap
+        from transformers.masking_utils import AttentionMaskInterface
+        from transformers.modeling_utils import AttentionInterface
 
-            _custom_sdpa_for_ring_kv_cache = get_custom_sdpa_for_ring_kv_cache(exportable_module)
-            if self.use_custom_sdpa:
-                if self.use_custom_kv_cache:
-                    AttentionInterface.register("custom_sdpa_ring_kv_cache", _custom_sdpa_for_ring_kv_cache)
-                    AttentionMaskInterface.register("custom_sdpa_ring_kv_cache", sdpa_mask_without_vmap)
-                    # Manually set the attention implementation to custom_sdpa_ring_kv_cache
-                    # This handles both regular sdpa and one for sliding window/local attention
-                    exportable_module.model.model.config._attn_implementation = "custom_sdpa_ring_kv_cache"
-                else:
-                    # Manually set the attention implementation to custom_sdpa_ring_kv_cache
-                    # This handles both regular sdpa and one for sliding window/local attention
-                    exportable_module.model.model.config._attn_implementation = "custom_sdpa"
+        _custom_sdpa_for_ring_kv_cache = get_custom_sdpa_for_ring_kv_cache(exportable_module)
+        if self.use_custom_sdpa:
+            if self.use_custom_kv_cache:
+                AttentionInterface.register("custom_sdpa_ring_kv_cache", _custom_sdpa_for_ring_kv_cache)
+                AttentionMaskInterface.register("custom_sdpa_ring_kv_cache", sdpa_mask_without_vmap)
+                # Manually set the attention implementation to custom_sdpa_ring_kv_cache
+                # This handles both regular sdpa and one for sliding window/local attention
+                exportable_module.model.model.config._attn_implementation = "custom_sdpa_ring_kv_cache"
+            else:
+                # Manually set the attention implementation to custom_sdpa_ring_kv_cache
+                # This handles both regular sdpa and one for sliding window/local attention
+                exportable_module.model.model.config._attn_implementation = "custom_sdpa"
 
     def export(
         self,
@@ -114,55 +112,48 @@ class CausalLMExportableModule(torch.nn.Module):
         logging.info(
             f"Exporting using input_ids({input_ids.shape})={input_ids}, cache_position({cache_position.shape})={cache_position}, dynamic_shapes={dynamic_shapes}, strict={strict}"
         )
-        if is_transformers_version(">", "4.52.0"):
-            from transformers.integrations.executorch import (
-                TorchExportableModuleForDecoderOnlyLM,
+
+        from transformers.integrations.executorch import (
+            TorchExportableModuleForDecoderOnlyLM,
+        )
+
+        exportable_module = TorchExportableModuleForDecoderOnlyLM(
+            self.model,
+            max_batch_size=1,
+            max_cache_len=self.metadata.get("get_max_seq_len"),
+        )
+        self._register_custom_attention(exportable_module)
+
+        if self.use_custom_kv_cache:
+            from optimum.executorch.attentions.custom_kv_cache import (
+                replace_with_et_custom_kv_cache,
             )
 
-            exportable_module = TorchExportableModuleForDecoderOnlyLM(
-                self.model,
-                max_batch_size=1,
-                max_cache_len=self.metadata.get("get_max_seq_len"),
-            )
-            self._register_attention_mask_for_4_53(exportable_module)
-
-            if self.use_custom_kv_cache:
-                from optimum.executorch.attentions.custom_kv_cache import (
-                    replace_with_et_custom_kv_cache,
-                )
-
-                replace_with_et_custom_kv_cache(
-                    exportable_module.model,
-                    self.model.config,
-                    self.model.generation_config,
-                    self.model.dtype,
-                )
-
-            with torch.no_grad():
-                exported_program = exportable_module.export(input_ids, cache_position, dynamic_shapes, strict)
-                # Apply RemoveTransposes pass to remove
-                # any back-to-back transpose ops that are not needed
-                # e.g. output of update_cache is transposed and
-                # input to custom_sdpa is transposed.
-                from executorch.extension.llm.export.export_passes import (
-                    RemoveRedundantTransposes,
-                )
-
-                mutated_gm = RemoveRedundantTransposes()(exported_program.module())[0]
-                exported_program = torch.export.export(
-                    mutated_gm,
-                    args=(input_ids, cache_position),
-                    kwargs={},
-                    dynamic_shapes=dynamic_shapes,
-                    strict=strict,
-                )
-        else:
-            # Path to use legacy API, static export only due to pinned transformers version
-            from transformers.integrations.executorch import (
-                convert_and_export_with_cache,
+            replace_with_et_custom_kv_cache(
+                exportable_module.model,
+                self.model.config,
+                self.model.generation_config,
+                self.model.dtype,
             )
 
-            exported_program = convert_and_export_with_cache(self.model, input_ids, cache_position)
+        with torch.no_grad():
+            exported_program = exportable_module.export(input_ids, cache_position, dynamic_shapes, strict)
+            # Apply RemoveTransposes pass to remove
+            # any back-to-back transpose ops that are not needed
+            # e.g. output of update_cache is transposed and
+            # input to custom_sdpa is transposed.
+            from executorch.extension.llm.export.export_passes import (
+                RemoveRedundantTransposes,
+            )
+
+            mutated_gm = RemoveRedundantTransposes()(exported_program.module())[0]
+            exported_program = torch.export.export(
+                mutated_gm,
+                args=(input_ids, cache_position),
+                kwargs={},
+                dynamic_shapes=dynamic_shapes,
+                strict=strict,
+            )
 
         return {"model": exported_program}
 

--- a/optimum/exporters/executorch/integrations.py
+++ b/optimum/exporters/executorch/integrations.py
@@ -399,8 +399,8 @@ class Seq2SeqLMExportableModule(torch.nn.Module):
         wrapped_decoder = (
             Seq2SeqLMDecoderExportableModuleWithStaticCache(
                 model=self.full_model,
-                max_static_cache_length=self.generation_config.cache_config.max_cache_len,
-                batch_size=self.generation_config.cache_config.batch_size,
+                max_static_cache_length=self.generation_config.cache_config.get("max_cache_len"),
+                batch_size=self.generation_config.cache_config.get("batch_size"),
             )
             .to("cpu")
             .eval()

--- a/optimum/exporters/executorch/quantization.py
+++ b/optimum/exporters/executorch/quantization.py
@@ -16,8 +16,6 @@ import logging
 from typing import Optional
 
 import torch
-import torchao
-from packaging.version import parse
 
 
 def quantize_model_(

--- a/optimum/exporters/executorch/quantization.py
+++ b/optimum/exporters/executorch/quantization.py
@@ -26,10 +26,6 @@ def quantize_model_(
     if not (qlinear_config or qembedding_config):
         return
 
-    # TODO: Update torchao to use 0.11.0 once released
-    if parse(torchao.__version__) < parse("0.11.0.dev0"):
-        raise RuntimeError("Quantization requires torchao >= 0.11.0. Please upgrade torchao.")
-
     from torchao.quantization.granularity import PerAxis, PerGroup
     from torchao.quantization.quant_api import (
         Int8DynamicActivationIntxWeightConfig,

--- a/optimum/exporters/executorch/quantization.py
+++ b/optimum/exporters/executorch/quantization.py
@@ -1,0 +1,82 @@
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Optional
+
+import torch
+import torchao
+from packaging.version import parse
+
+
+def quantize_model_(
+    eager_model: torch.nn.Module, qlinear_config: Optional[str], qembedding_config: Optional[str]
+) -> torch.nn.Module:
+    if not (qlinear_config or qembedding_config):
+        return
+
+    # TODO: Update torchao to use 0.11.0 once released
+    if parse(torchao.__version__) < parse("0.11.0.dev0"):
+        raise RuntimeError("Quantization requires torchao >= 0.11.0. Please upgrade torchao.")
+
+    from torchao.quantization.granularity import PerAxis, PerGroup
+    from torchao.quantization.quant_api import (
+        Int8DynamicActivationIntxWeightConfig,
+        IntxWeightOnlyConfig,
+        quantize_,
+    )
+    from torchao.utils import unwrap_tensor_subclass
+
+    if qembedding_config:
+        logging.info("Quantizing embedding layers.")
+        embedding_config = {
+            "4w": IntxWeightOnlyConfig(
+                weight_dtype=torch.int4,
+                granularity=PerGroup(32),
+            ),
+            "8w": IntxWeightOnlyConfig(
+                weight_dtype=torch.int8,
+                granularity=PerAxis(0),
+            ),
+        }[qembedding_config]
+
+        # TODO: Should switch to `AOPerModuleConfig` once fix for tied weights is available.
+        quantize_(
+            eager_model,
+            embedding_config,
+            lambda m, fqn: isinstance(m, torch.nn.Embedding),
+        )
+
+    if qlinear_config:
+        logging.info("Quantizing linear layers.")
+        linear_config = {
+            "8da4w": Int8DynamicActivationIntxWeightConfig(
+                weight_dtype=torch.int4,
+                weight_granularity=PerGroup(32),
+            ),
+            "4w": IntxWeightOnlyConfig(
+                weight_dtype=torch.int4,
+                granularity=PerGroup(32),
+            ),
+            "8w": IntxWeightOnlyConfig(
+                weight_dtype=torch.int8,
+                granularity=PerAxis(0),
+            ),
+        }[qlinear_config]
+        quantize_(
+            eager_model,
+            linear_config,
+        )
+
+    unwrap_tensor_subclass(eager_model)

--- a/optimum/exporters/executorch/quantization.py
+++ b/optimum/exporters/executorch/quantization.py
@@ -16,8 +16,6 @@ import logging
 from typing import Optional
 
 import torch
-import torchao
-from packaging.version import parse
 
 
 def quantize_model_(
@@ -25,10 +23,6 @@ def quantize_model_(
 ) -> torch.nn.Module:
     if not (qlinear_config or qembedding_config):
         return
-
-    # TODO: Update torchao to use 0.11.0 once released
-    if parse(torchao.__version__) < parse("0.11.0.dev0"):
-        raise RuntimeError("Quantization requires torchao >= 0.11.0. Please upgrade torchao.")
 
     from torchao.quantization.granularity import PerAxis, PerGroup
     from torchao.quantization.quant_api import (

--- a/optimum/exporters/executorch/tasks/causal_lm.py
+++ b/optimum/exporters/executorch/tasks/causal_lm.py
@@ -14,12 +14,11 @@
 
 import logging
 
-import torch
 import torchao
-from packaging.version import parse
 from transformers import AutoConfig, AutoModelForCausalLM, GenerationConfig
 
 from ..integrations import CausalLMExportableModule
+from ..quantization import quantize_model_
 from ..task_registry import register_task
 
 
@@ -130,64 +129,8 @@ def load_causal_lm_model(model_name_or_path: str, **kwargs) -> CausalLMExportabl
         if isinstance(param, torchao.utils.TorchAOBaseTensor):
             param.requires_grad = False
 
-    # TODO: Move quantization recipe out for better composability.
-    # TODO: Should switch to `TorchAoConfig` once the quant issue on final lm_head layer is fixed.
     qlinear_config = kwargs.get("qlinear", None)
     qembedding_config = kwargs.get("qembedding", None)
-    if qlinear_config or qembedding_config:
-        # TODO: Update torchao to use 0.11.0 once released
-        if parse(torchao.__version__) < parse("0.11.0.dev0"):
-            raise RuntimeError("Quantization 8da4w requires torchao >= 0.11.0. Please upgrade torchao.")
-
-        from torchao.quantization.granularity import PerAxis, PerGroup
-        from torchao.quantization.quant_api import (
-            Int8DynamicActivationIntxWeightConfig,
-            IntxWeightOnlyConfig,
-            quantize_,
-        )
-        from torchao.utils import unwrap_tensor_subclass
-
-        if qembedding_config:
-            logging.info("Quantizing embedding layers.")
-            embedding_config = {
-                "4w": IntxWeightOnlyConfig(
-                    weight_dtype=torch.int4,
-                    granularity=PerGroup(32),
-                ),
-                "8w": IntxWeightOnlyConfig(
-                    weight_dtype=torch.int8,
-                    granularity=PerAxis(0),
-                ),
-            }[qembedding_config]
-
-            # TODO: Should switch to `AOPerModuleConfig` once fix for tied weights is available.
-            quantize_(
-                eager_model,
-                embedding_config,
-                lambda m, fqn: isinstance(m, torch.nn.Embedding),
-            )
-
-        if qlinear_config:
-            logging.info("Quantizing linear layers.")
-            linear_config = {
-                "8da4w": Int8DynamicActivationIntxWeightConfig(
-                    weight_dtype=torch.int4,
-                    weight_granularity=PerGroup(32),
-                ),
-                "4w": IntxWeightOnlyConfig(
-                    weight_dtype=torch.int4,
-                    granularity=PerGroup(32),
-                ),
-                "8w": IntxWeightOnlyConfig(
-                    weight_dtype=torch.int8,
-                    granularity=PerAxis(0),
-                ),
-            }[qlinear_config]
-            quantize_(
-                eager_model,
-                linear_config,
-            )
-
-        unwrap_tensor_subclass(eager_model)
+    quantize_model_(eager_model, qlinear_config=qlinear_config, qembedding_config=qembedding_config)
 
     return CausalLMExportableModule(eager_model, use_custom_kv_cache, use_custom_sdpa)

--- a/optimum/exporters/executorch/tasks/causal_lm.py
+++ b/optimum/exporters/executorch/tasks/causal_lm.py
@@ -149,11 +149,18 @@ def load_causal_lm_model(model_name_or_path: str, **kwargs) -> CausalLMExportabl
 
         if qembedding_config:
             logging.info("Quantizing embedding layers.")
+            embedding_config = {
+                "4w": IntxWeightOnlyConfig(
+                    weight_dtype=torch.int4,
+                    granularity=PerGroup(32),
+                ),
+                "8w": IntxWeightOnlyConfig(
+                    weight_dtype=torch.int8,
+                    granularity=PerAxis(0),
+                ),
+            }[qembedding_config]
+
             # TODO: Should switch to `AOPerModuleConfig` once fix for tied weights is available.
-            embedding_config = IntxWeightOnlyConfig(
-                weight_dtype=torch.int8,
-                granularity=PerAxis(0),
-            )
             quantize_(
                 eager_model,
                 embedding_config,
@@ -162,10 +169,20 @@ def load_causal_lm_model(model_name_or_path: str, **kwargs) -> CausalLMExportabl
 
         if qlinear_config:
             logging.info("Quantizing linear layers.")
-            linear_config = Int8DynamicActivationIntxWeightConfig(
-                weight_dtype=torch.int4,
-                weight_granularity=PerGroup(32),
-            )
+            linear_config = {
+                "8da4w": Int8DynamicActivationIntxWeightConfig(
+                    weight_dtype=torch.int4,
+                    weight_granularity=PerGroup(32),
+                ),
+                "4w": IntxWeightOnlyConfig(
+                    weight_dtype=torch.int4,
+                    granularity=PerGroup(32),
+                ),
+                "8w": IntxWeightOnlyConfig(
+                    weight_dtype=torch.int8,
+                    granularity=PerAxis(0),
+                ),
+            }[qlinear_config]
             quantize_(
                 eager_model,
                 linear_config,

--- a/optimum/exporters/executorch/tasks/causal_lm.py
+++ b/optimum/exporters/executorch/tasks/causal_lm.py
@@ -53,6 +53,7 @@ def load_causal_lm_model(model_name_or_path: str, **kwargs) -> CausalLMExportabl
     device = "cpu"
     batch_size = 1
     dtype = kwargs.get("dtype", "float32")
+    disable_dynamic_shapes = kwargs.get("disable_dynamic_shapes", False)
     use_custom_sdpa = kwargs.get("use_custom_sdpa", False)
     use_custom_kv_cache = kwargs.get("use_custom_kv_cache", False)
     attn_implementation = kwargs.get("attn_implementation", "custom_sdpa" if use_custom_sdpa else "sdpa")
@@ -133,4 +134,4 @@ def load_causal_lm_model(model_name_or_path: str, **kwargs) -> CausalLMExportabl
     qembedding_config = kwargs.get("qembedding", None)
     quantize_model_(eager_model, qlinear_config=qlinear_config, qembedding_config=qembedding_config)
 
-    return CausalLMExportableModule(eager_model, use_custom_kv_cache, use_custom_sdpa)
+    return CausalLMExportableModule(eager_model, use_custom_kv_cache, use_custom_sdpa, disable_dynamic_shapes)

--- a/optimum/exporters/executorch/tasks/masked_lm.py
+++ b/optimum/exporters/executorch/tasks/masked_lm.py
@@ -15,6 +15,7 @@
 from transformers import AutoModelForMaskedLM
 
 from ..integrations import MaskedLMExportableModule
+from ..quantization import quantize_model_
 from ..task_registry import register_task
 
 
@@ -38,5 +39,10 @@ def load_masked_lm_model(model_name_or_path: str, **kwargs) -> MaskedLMExportabl
             An instance of `MaskedLMExportableModule` for exporting and lowering to ExecuTorch.
     """
 
-    eager_model = AutoModelForMaskedLM.from_pretrained(model_name_or_path, **kwargs).to("cpu").eval()
+    eager_model = AutoModelForMaskedLM.from_pretrained(model_name_or_path).to("cpu").eval()
+
+    qlinear_config = kwargs.get("qlinear", None)
+    qembedding_config = kwargs.get("qembedding", None)
+    quantize_model_(eager_model, qlinear_config=qlinear_config, qembedding_config=qembedding_config)
+
     return MaskedLMExportableModule(eager_model)

--- a/optimum/exporters/executorch/utils.py
+++ b/optimum/exporters/executorch/utils.py
@@ -53,8 +53,8 @@ def save_config_to_constant_methods(
         # Check for cache_config and its attributes
         cache_config = getattr(generation_config, "cache_config", None)
         if cache_config is not None:
-            max_batch_size = cache_config.get("batch_size")
-            max_seq_len = cache_config.get("max_cache_len")
+            max_batch_size = getattr(cache_config, "batch_size", None)
+            max_seq_len = getattr(cache_config, "max_cache_len", None)
 
             if max_batch_size is not None:
                 metadata["get_max_batch_size"] = max_batch_size

--- a/optimum/exporters/executorch/utils.py
+++ b/optimum/exporters/executorch/utils.py
@@ -53,8 +53,8 @@ def save_config_to_constant_methods(
         # Check for cache_config and its attributes
         cache_config = getattr(generation_config, "cache_config", None)
         if cache_config is not None:
-            max_batch_size = getattr(cache_config, "batch_size", None)
-            max_seq_len = getattr(cache_config, "max_cache_len", None)
+            max_batch_size = cache_config.get("batch_size")
+            max_seq_len = cache_config.get("max_cache_len")
 
             if max_batch_size is not None:
                 metadata["get_max_batch_size"] = max_batch_size

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except Exception as error:
 INSTALL_REQUIRE = [
     "optimum~=1.24",
     "executorch>=0.6.0",
-    "transformers==4.54.1",
+    "transformers==4.51.3",
 ]
 
 TESTS_REQUIRE = [

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except Exception as error:
 INSTALL_REQUIRE = [
     "optimum~=1.24",
     "executorch>=0.6.0",
-    "transformers==4.51.3",
+    "transformers==4.54.1",
 ]
 
 TESTS_REQUIRE = [

--- a/tests/models/test_modeling_codegen.py
+++ b/tests/models/test_modeling_codegen.py
@@ -54,7 +54,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             model_id,
             config=config,
             recipe="xnnpack",
-            **{"qlinear": True, "qembeeding": True},
+            **{"qlinear": "8da4w", "qembeeding": "8w"},
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling_gemma.py
+++ b/tests/models/test_modeling_gemma.py
@@ -56,8 +56,8 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
                     --recipe {recipe} \
                     --output_dir {tempdir}/executorch \
                     --use_custom_sdpa \
-                    --qlinear \
-                    --qembedding",
+                    --qlinear 8da4w \
+                    --qembedding 8w",
                 shell=True,
                 check=True,
             )
@@ -76,7 +76,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         # model_id = "google/gemma-2b"
         model_id = "weqweasdas/RM-Gemma-2B"
         # ExecuTorch model + custom sdpa + 8da4w linear quantization + int8 embedding quantization
-        kwargs = {"qlinear": True, "qembedding": True}
+        kwargs = {"qlinear": "8da4w", "qembedding": "8w"}
         model = ExecuTorchModelForCausalLM.from_pretrained(
             model_id,
             recipe="xnnpack",

--- a/tests/models/test_modeling_gemma2.py
+++ b/tests/models/test_modeling_gemma2.py
@@ -61,8 +61,8 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
                     --recipe {recipe} \
                     --output_dir {tempdir}/executorch \
                     --use_custom_sdpa \
-                    --qlinear \
-                    --qembedding",
+                    --qlinear 8da4w \
+                    --qembedding 8w",
                 shell=True,
                 check=True,
             )
@@ -81,7 +81,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         # model_id = "google/gemma-2-2b"
         model_id = "unsloth/gemma-2-2b-it"
         # ExecuTorch model + custom sdpa + 8da4w linear quantization + int8 embedding quantization
-        kwargs = {"qlinear": True, "qembedding": True}
+        kwargs = {"qlinear": "8da4w", "qembedding": "8w"}
         model = ExecuTorchModelForCausalLM.from_pretrained(
             model_id,
             recipe="xnnpack",

--- a/tests/models/test_modeling_gemma3.py
+++ b/tests/models/test_modeling_gemma3.py
@@ -22,15 +22,11 @@ import tempfile
 import unittest
 
 import pytest
-import torchao
-import transformers
 from executorch.extension.pybindings.portable_lib import ExecuTorchModule
-from packaging.version import parse
 from transformers import AutoTokenizer
 from transformers.testing_utils import slow
 
 from optimum.executorch import ExecuTorchModelForCausalLM
-from optimum.utils.import_utils import is_transformers_version
 
 from ..utils import check_causal_lm_output_quality
 
@@ -41,10 +37,6 @@ is_linux_ci = sys.platform.startswith("linux") and os.environ.get("GITHUB_ACTION
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 
-@pytest.mark.skipif(
-    is_transformers_version("<", "4.52.0.dev0"),
-    reason="Only available on transformers >= 4.52.0.dev0",
-)
 class ExecuTorchModelIntegrationTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -119,10 +111,6 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     @slow
     @pytest.mark.run_slow
     @pytest.mark.skipif(is_linux_ci, reason="OOM on linux runner")
-    @pytest.mark.skipif(
-        parse(transformers.__version__) < parse("4.53.0.dev0") or parse(torchao.__version__) < parse("0.11.0"),
-        reason="Only available on transformers >= 4.53.0.dev0 and torchao >= 0.11.0",
-    )
     def test_gemma3_text_generation_with_custom_sdpa(self):
         # TODO: Until https://github.com/huggingface/optimum/issues/2127 is fixed, have to use non-gated model on CI
         # model_id = "google/gemma-3-1b-it"
@@ -191,10 +179,6 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
     @slow
     @pytest.mark.run_slow
-    @pytest.mark.skipif(
-        parse(transformers.__version__) < parse("4.53.0.dev0") or parse(torchao.__version__) < parse("0.11.0"),
-        reason="Only available on transformers >= 4.53.0.dev0 and torchao >= 0.11.0",
-    )
     def test_gemma3_text_generation_with_custom_sdpa_8da4w_8we(self):
         # TODO: Until https://github.com/huggingface/optimum/issues/2127 is fixed, have to use non-gated model on CI
         # model_id = "google/gemma-3-1b-it"
@@ -230,10 +214,6 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
     @slow
     @pytest.mark.run_slow
-    @pytest.mark.skipif(
-        parse(transformers.__version__) < parse("4.53.0.dev0") or parse(torchao.__version__) < parse("0.11.0"),
-        reason="Only available on transformers >= 4.53.0.dev0 and torchao >= 0.11.0",
-    )
     def test_gemma3_text_generation_with_custom_sdpa_kv_cache_8da4w_8we(self):
         # TODO: Until https://github.com/huggingface/optimum/issues/2127 is fixed, have to use non-gated model on CI
         # model_id = "google/gemma-3-1b-it"

--- a/tests/models/test_modeling_gemma3.py
+++ b/tests/models/test_modeling_gemma3.py
@@ -66,8 +66,8 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
                     --recipe {recipe} \
                     --output_dir {tempdir}/executorch \
                     --use_custom_sdpa \
-                    --qlinear \
-                    --qembedding",
+                    --qlinear 8da4w \
+                    --qembedding 8w",
                 shell=True,
                 check=True,
             )
@@ -202,7 +202,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         prompt = "Write a poem about a machine learning."
 
         # ExecuTorch model + custom sdpa + 8da4w linear quantization + int8 embedding quantization
-        kwargs = {"qlinear": True, "qembedding": True}
+        kwargs = {"qlinear": "8da4w", "qembedding": "8w"}
         model = ExecuTorchModelForCausalLM.from_pretrained(
             model_id,
             recipe="xnnpack",
@@ -241,7 +241,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         prompt = "Write a poem about a machine learning."
 
         # ExecuTorch model + custom sdpa + 8da4w linear quantization + int8 embedding quantization
-        kwargs = {"qlinear": True, "qembedding": True}
+        kwargs = {"qlinear": "8da4w", "qembedding": "8w"}
         model = ExecuTorchModelForCausalLM.from_pretrained(
             model_id,
             recipe="xnnpack",

--- a/tests/models/test_modeling_glm.py
+++ b/tests/models/test_modeling_glm.py
@@ -52,7 +52,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             recipe="xnnpack",
             attn_implementation="custom_sdpa",
             use_custom_kv_cache=True,
-            **{"qlinear": True, "qembeeding": True},
+            **{"qlinear": "8da4w", "qembeeding": "8w"},
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling_gpt2.py
+++ b/tests/models/test_modeling_gpt2.py
@@ -52,7 +52,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             recipe="xnnpack",
             attn_implementation="custom_sdpa",
             use_custom_kv_cache=True,
-            **{"qlinear": True, "qembeeding": True},
+            **{"qlinear": "8da4w", "qembeeding": "8w"},
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling_gptj.py
+++ b/tests/models/test_modeling_gptj.py
@@ -54,7 +54,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             model_id,
             config=config,
             recipe="xnnpack",
-            **{"qlinear": True, "qembeeding": True},
+            **{"qlinear": "8da4w", "qembeeding": "8w"},
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling_gptneox.py
+++ b/tests/models/test_modeling_gptneox.py
@@ -52,7 +52,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             recipe="xnnpack",
             attn_implementation="custom_sdpa",
             use_custom_kv_cache=True,
-            **{"qlinear": True, "qembeeding": True},
+            **{"qlinear": "8da4w", "qembeeding": "8w"},
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling_gptneoxjapanese.py
+++ b/tests/models/test_modeling_gptneoxjapanese.py
@@ -57,7 +57,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             model_id,
             config=config,
             recipe="xnnpack",
-            **{"qlinear": True, "qembeeding": True},
+            **{"qlinear": "8da4w", "qembeeding": "8w"},
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling_granite.py
+++ b/tests/models/test_modeling_granite.py
@@ -52,7 +52,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             recipe="xnnpack",
             attn_implementation="custom_sdpa",
             use_custom_kv_cache=True,
-            **{"qlinear": True, "qembeeding": True},
+            **{"qlinear": "8da4w", "qembeeding": "8w"},
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling_llama.py
+++ b/tests/models/test_modeling_llama.py
@@ -55,8 +55,8 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
                     --recipe {recipe} \
                     --use_custom_sdpa \
                     --use_custom_kv_cache \
-                    --qlinear \
-                    --qembedding \
+                    --qlinear 8da4w \
+                    --qembedding 8w \
                     --output_dir {tempdir}/executorch",
                 shell=True,
                 check=True,
@@ -74,7 +74,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     def test_llama_text_generation_with_custom_sdpa_8da4w_8we(self):
         # ExecuTorch model + custom sdpa + 8da4w linear quantization + int8 embedding quantization
         model_id = "NousResearch/Llama-3.2-1B"
-        kwargs = {"qlinear": True, "qembedding": True}
+        kwargs = {"qlinear": "8da4w", "qembedding": "8w"}
         model = ExecuTorchModelForCausalLM.from_pretrained(
             model_id,
             recipe="xnnpack",
@@ -109,7 +109,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             recipe="xnnpack",
             attn_implementation="custom_sdpa",
             use_custom_kv_cache=True,
-            **{"qlinear": True, "qembeeding": True},
+            **{"qlinear": "8da4w", "qembedding": "8w"},
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling_mistral.py
+++ b/tests/models/test_modeling_mistral.py
@@ -52,7 +52,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             recipe="xnnpack",
             attn_implementation="custom_sdpa",
             use_custom_kv_cache=True,
-            **{"qlinear": True, "qembeeding": True},
+            **{"qlinear": "8da4w", "qembeeding": "8w"},
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling_olmo.py
+++ b/tests/models/test_modeling_olmo.py
@@ -58,8 +58,8 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
                     --recipe {recipe} \
                     --output_dir {tempdir}/executorch \
                     --use_custom_sdpa \
-                    --qlinear \
-                    --qembedding",
+                    --qlinear 8da4w \
+                    --qembedding 8w",
                 shell=True,
                 check=True,
             )
@@ -95,7 +95,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     def test_olmo_text_generation_with_custom_sdpa_8da4w_8we(self):
         # ExecuTorch model + custom sdpa + 8da4w linear quantization + int8 embedding quantization
         model_id = "allenai/OLMo-1B-hf"
-        kwargs = {"qlinear": True, "qembedding": True}
+        kwargs = {"qlinear": "8da4w", "qembedding": "8w"}
         model = ExecuTorchModelForCausalLM.from_pretrained(
             model_id,
             recipe="xnnpack",
@@ -130,7 +130,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             recipe="xnnpack",
             attn_implementation="custom_sdpa",
             use_custom_kv_cache=True,
-            **{"qlinear": True, "qembeeding": True},
+            **{"qlinear": "8da4w", "qembedding": "8w"},
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling_phi.py
+++ b/tests/models/test_modeling_phi.py
@@ -52,7 +52,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             recipe="xnnpack",
             attn_implementation="custom_sdpa",
             use_custom_kv_cache=True,
-            **{"qlinear": True, "qembeeding": True},
+            **{"qlinear": "8da4w", "qembeeding": "8w"},
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling_phi4.py
+++ b/tests/models/test_modeling_phi4.py
@@ -21,7 +21,6 @@ import unittest
 
 import pytest
 import torchao
-import transformers
 from executorch.extension.pybindings.portable_lib import ExecuTorchModule
 from packaging.version import parse
 from transformers import AutoConfig, AutoTokenizer
@@ -43,12 +42,6 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
     @slow
     @pytest.mark.run_slow
-    @pytest.mark.skipif(
-        is_linux_ci
-        or parse(transformers.__version__) < parse("4.52.0")
-        or parse(torchao.__version__) < parse("0.11.0"),
-        reason="Only available on transformers >= 4.52.0 and torchao >= 0.11.0. OOM on linux runner.",
-    )
     def test_phi4_text_generation_with_custom_sdpa_and_kv_cache_8da4w_8we(self):
         model_id = "microsoft/Phi-4-mini-instruct"
         model = ExecuTorchModelForCausalLM.from_pretrained(

--- a/tests/models/test_modeling_phi4.py
+++ b/tests/models/test_modeling_phi4.py
@@ -56,7 +56,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             recipe="xnnpack",
             attn_implementation="custom_sdpa",
             use_custom_kv_cache=True,
-            **{"qlinear": True, "qembeeding": True},
+            **{"qlinear": "8da4w", "qembedding": "8w"},
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling_qwen3.py
+++ b/tests/models/test_modeling_qwen3.py
@@ -62,8 +62,8 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
                     --recipe {recipe} \
                     --output_dir {tempdir}/executorch \
                     --use_custom_sdpa \
-                    --qlinear \
-                    --qembedding",
+                    --qlinear 8da4w \
+                    --qembedding 8w",
                 shell=True,
                 check=True,
             )
@@ -188,7 +188,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 
         # ExecuTorch model + custom sdpa + 8da4w linear quantization + int8 embedding quantization
-        kwargs = {"qlinear": True, "qembedding": True}
+        kwargs = {"qlinear": "8da4w", "qembedding": "8w"}
         model = ExecuTorchModelForCausalLM.from_pretrained(
             model_id,
             recipe="xnnpack",
@@ -262,7 +262,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             recipe="xnnpack",
             attn_implementation="custom_sdpa",
             use_custom_kv_cache=True,
-            **{"qlinear": True, "qembeeding": True},
+            **{"qlinear": "8da4w", "qembedding": "8w"},
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling_qwen3.py
+++ b/tests/models/test_modeling_qwen3.py
@@ -23,7 +23,6 @@ import unittest
 
 import pytest
 import torchao
-import transformers
 from executorch import version
 from executorch.extension.pybindings.portable_lib import ExecuTorchModule
 from packaging.version import parse
@@ -214,10 +213,6 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
     @slow
     @pytest.mark.run_slow
-    @pytest.mark.skipif(
-        parse(transformers.__version__) < parse("4.52.0.dev0"),
-        reason="Only available on transformers >= 4.52.0.dev0",
-    )
     def test_qwen3_text_generation_with_custom_sdpa_and_kv_cache(self):
         model_id = "Qwen/Qwen3-0.6B"
         prompt = "Give me a short introduction to large language model."
@@ -249,10 +244,6 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
     @slow
     @pytest.mark.run_slow
-    @pytest.mark.skipif(
-        parse(transformers.__version__) < parse("4.52.0") or parse(torchao.__version__) < parse("0.11.0"),
-        reason="Only available on transformers >= 4.52.0 and torchao >= 0.11.0",
-    )
     def test_qwen3_text_generation_with_custom_sdpa_and_kv_cache_8da4w_8we(self):
         model_id = "Qwen/Qwen3-0.6B"
         prompt = "Give me a short introduction to large language model."

--- a/tests/models/test_modeling_qwen3_embedding.py
+++ b/tests/models/test_modeling_qwen3_embedding.py
@@ -19,8 +19,6 @@ import os
 import unittest
 
 import pytest
-import torchao
-import transformers
 from executorch import version
 from executorch.extension.pybindings.portable_lib import ExecuTorchModule
 from packaging.version import parse
@@ -41,10 +39,6 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
     @slow
     @pytest.mark.run_slow
-    @pytest.mark.skipif(
-        parse(transformers.__version__) < parse("4.52.0") or parse(torchao.__version__) < parse("0.11.0"),
-        reason="Only available on transformers >= 4.52.0 and torchao >= 0.11.0",
-    )
     def test_qwen3_embedding_text_generation_with_custom_sdpa_and_kv_cache_8da4w_8we(self):
         model_id = "Qwen/Qwen3-Embedding-0.6B"
         prompt = "Explain gravity"

--- a/tests/models/test_modeling_qwen3_embedding.py
+++ b/tests/models/test_modeling_qwen3_embedding.py
@@ -54,7 +54,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             recipe="xnnpack",
             attn_implementation="custom_sdpa",
             use_custom_kv_cache=True,
-            **{"qlinear": True, "qembeeding": True},
+            **{"qlinear": "8da4w", "qembedding": "8w"},
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling_smollm.py
+++ b/tests/models/test_modeling_smollm.py
@@ -139,7 +139,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         prompt = "My favourite condiment is "
 
         # ExecuTorch model + custom sdpa + 8da4w linear quantization
-        kwargs = {"qlinear": True}
+        kwargs = {"qlinear": "8da4w"}
         model = ExecuTorchModelForCausalLM.from_pretrained(
             model_id,
             recipe="xnnpack",
@@ -176,7 +176,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         prompt = "My favourite condiment is "
 
         # ExecuTorch model + custom sdpa + 8da4w linear quantization + int8 embedding quantization
-        kwargs = {"qlinear": True, "qembedding": True}
+        kwargs = {"qlinear": "8da4w", "qembedding": "8w"}
         model = ExecuTorchModelForCausalLM.from_pretrained(
             model_id,
             recipe="xnnpack",
@@ -217,7 +217,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             recipe="xnnpack",
             attn_implementation="custom_sdpa",
             use_custom_kv_cache=True,
-            **{"qlinear": True, "qembeeding": True},
+            **{"qlinear": "8da4w", "qembedding": "8w"},
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling_smollm3.py
+++ b/tests/models/test_modeling_smollm3.py
@@ -36,7 +36,7 @@ is_linux_ci = sys.platform.startswith("linux") and is_ci
 
 
 @pytest.mark.skipif(
-    is_transformers_version("<", "4.53.1") or is_linux_ci,
+    is_transformers_version("<", "4.53.1"),
     reason="Only available on transformers >= 4.53.1",
 )
 class ExecuTorchModelIntegrationTest(unittest.TestCase):

--- a/tests/models/test_modeling_smollm3.py
+++ b/tests/models/test_modeling_smollm3.py
@@ -25,7 +25,6 @@ from transformers import AutoTokenizer
 from transformers.testing_utils import slow
 
 from optimum.executorch import ExecuTorchModelForCausalLM
-from optimum.utils.import_utils import is_transformers_version
 
 from ..utils import check_causal_lm_output_quality
 
@@ -35,10 +34,7 @@ is_ci = os.environ.get("GITHUB_ACTIONS") == "true"
 is_linux_ci = sys.platform.startswith("linux") and is_ci
 
 
-@pytest.mark.skipif(
-    is_transformers_version("<", "4.53.1"),
-    reason="Only available on transformers >= 4.53.1",
-)
+@pytest.mark.skipif(is_linux_ci)
 class ExecuTorchModelIntegrationTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/models/test_modeling_smollm3.py
+++ b/tests/models/test_modeling_smollm3.py
@@ -25,7 +25,6 @@ from transformers import AutoTokenizer
 from transformers.testing_utils import slow
 
 from optimum.executorch import ExecuTorchModelForCausalLM
-from optimum.utils.import_utils import is_transformers_version
 
 from ..utils import check_causal_lm_output_quality
 
@@ -35,10 +34,7 @@ is_ci = os.environ.get("GITHUB_ACTIONS") == "true"
 is_linux_ci = sys.platform.startswith("linux") and is_ci
 
 
-@pytest.mark.skipif(
-    is_transformers_version("<", "4.53.1") or is_linux_ci,
-    reason="Only available on transformers >= 4.53.1",
-)
+@pytest.mark.skipif(is_linux_ci, reason="Runner OOM")
 class ExecuTorchModelIntegrationTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -76,7 +72,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     @slow
     @pytest.mark.run_slow
     @pytest.mark.portable
-    @pytest.mark.skipif(is_ci, reason="Too big for CI runners")
+    @pytest.mark.skipif(is_ci, reason="Runner OOM")
     def test_smollm3_text_generation_portable(self):
         model_id = "HuggingFaceTB/SmolLM3-3B"
         prompt = "Give me a brief explanation of gravity in simple terms."

--- a/tests/models/test_modeling_smollm3.py
+++ b/tests/models/test_modeling_smollm3.py
@@ -54,7 +54,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             recipe="xnnpack",
             attn_implementation="custom_sdpa",
             use_custom_kv_cache=True,
-            **{"qlinear": True, "qembeeding": True},
+            **{"qlinear": "8da4w", "qembedding": "8w"},
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling_starcoder2.py
+++ b/tests/models/test_modeling_starcoder2.py
@@ -52,7 +52,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             recipe="xnnpack",
             attn_implementation="custom_sdpa",
             use_custom_kv_cache=True,
-            **{"qlinear": True, "qembeeding": True},
+            **{"qlinear": "8da4w", "qembeeding": "8w"},
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling_vit.py
+++ b/tests/models/test_modeling_vit.py
@@ -89,30 +89,4 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     @pytest.mark.run_slow
     @pytest.mark.skipif(is_not_macos, reason="Only runs on MacOS")
     def test_vit_image_classification_coreml_fp32_cpu(self):
-        model_id = "google/vit-base-patch16-224"
-
-        config = AutoConfig.from_pretrained(model_id)
-        batch_size = 1
-        num_channels = config.num_channels
-        height = config.image_size
-        width = config.image_size
-        pixel_values = torch.rand(batch_size, num_channels, height, width)
-
-        # Test fetching and lowering the model to ExecuTorch
-        import coremltools as ct
-
-        et_model = ExecuTorchModelForImageClassification.from_pretrained(
-            model_id=model_id,
-            recipe="coreml",
-            recipe_kwargs={"compute_precision": ct.precision.FLOAT32, "compute_units": ct.ComputeUnit.CPU_ONLY},
-        )
-        self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
-        self.assertIsInstance(et_model.model, ExecuTorchModule)
-
-        eager_model = AutoModelForImageClassification.from_pretrained(model_id).eval().to("cpu")
-        with torch.no_grad():
-            eager_output = eager_model(pixel_values)
-            et_output = et_model.forward(pixel_values)
-
-        # Compare with eager outputs
-        self.assertTrue(check_close_recursively(eager_output.logits, et_output))
+        self._helper_vit_image_classification(recipe="coreml_fp32_cpu")

--- a/tests/models/test_modeling_whisper.py
+++ b/tests/models/test_modeling_whisper.py
@@ -28,16 +28,11 @@ from transformers import AutoProcessor, AutoTokenizer
 from transformers.testing_utils import slow
 
 from optimum.executorch import ExecuTorchModelForSpeechSeq2Seq
-from optimum.utils.import_utils import is_transformers_version
 
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 
-@pytest.mark.skipif(
-    is_transformers_version(">", "4.52.4"),
-    reason="Need to fix in the transformers due to attention refactor https://github.com/huggingface/transformers/pull/38235",
-)
 class ExecuTorchModelIntegrationTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
```
>> python -m pytest tests/models/test_modeling_gemma3.py -k test_gemma3_270m_text_genera
tion_with_custom_sdpa_8da4w_8we -s --log-cli-level=INFO

⚠️  DISCLAIMER: Python-based perf measurements are approximate and may not match absolute speeds on Android/iOS apps. They are intended for relative comparisons—-e.g. SDPA vs. custom SDPA, FP16 vs. FP32—-so you can]
 gauge performance improvements from each optimization step. For end-to-end, platform-accurate benchmarks, please use the official ExecuTorch apps:
  • iOS:     https://github.com/pytorch/executorch/tree/main/extension/benchmark/apple/Benchmark
  • Android: https://github.com/pytorch/executorch/tree/main/extension/benchmark/android/benchmark

PyTorchObserver {"prompt_tokens": 5, "generated_tokens": 59, "model_load_start_ms": 0, "model_load_end_ms": 0, "inference_start_ms": 1755291853770, "token_encode_end_ms": 1755291853770, "model_execution_start_ms": 1755291860848, "model_execution_end_ms": 1755291860962, "inference_end_ms": 1755291860963, "prompt_eval_end_ms": 1755291854355, "first_token_ms": 1755291854468, "aggregate_sampling_time_ms": 7168, "SCALING_FACTOR_UNITS_PER_SECOND": 1000}
        Prompt Tokens: 5 Generated Tokens: 59
        Model Load Time:                0.000000 (seconds)
        Total inference time:           7.193000 (seconds)               Rate:  8.202419 (tokens/second)
                Prompt evaluation:      0.585000 (seconds)               Rate:  8.547009 (tokens/second)
                Generated 59 tokens:    6.608000 (seconds)               Rate:  8.928571 (tokens/second)
        Time to first generated token:  0.698000 (seconds)
        Sampling time over 64 tokens:   7.168000 (seconds)
INFO     root:test_modeling_gemma3.py:272
Generated text:
        Are seals friendly?

**Yes, all seals are friendly.**

**We can also be more mindful of our surroundings.**

**We can also be more aware of our emotions.**

**We can also be more empathetic towards others.**

**We can be more grateful for what we have.**

**We
INFO     root:modeling.py:120 Cleaning up temporary directory: /var/folders/p_/bvy3h_s57w18gxl7p2sy_p9w0000gn/T/executorch_export_bkiokkqb
INFO     root:modeling.py:122 Temporary directory cleanup completed
INFO     root:utils.py:35 Starting perplexity check with model 'unsloth/gemma-3-270m-it' ...
INFO     root:utils.py:55 ✓ Perplexity check passed: 4.72 <= 100.0
PASSED
```