### PR TITLE
Unsqueeze encoder output in graph

### DIFF
--- a/optimum/executorch/modeling.py
+++ b/optimum/executorch/modeling.py
@@ -1030,6 +1030,7 @@ class ExecuTorchModelForSpeechSeq2Seq(ExecuTorchModelBase):
         self.stats.on_model_execution_start()
         if is_first_prediction:
             encoder_outputs = self.encoder.forward((input_features,))[0]
+            encoder_outputs = encoder_outputs.squeeze(dim=0)
             self.stats.on_prompt_eval_end()
 
         result = (self.decoder.forward((decoder_input_ids, encoder_outputs, cache_position))[0], encoder_outputs)

--- a/optimum/exporters/executorch/integrations.py
+++ b/optimum/exporters/executorch/integrations.py
@@ -87,7 +87,7 @@ class VoxtralEncoderExportableModule(torch.nn.Module):
         audio_hidden_states = audio_outputs.last_hidden_state
         audio_hidden_states = audio_hidden_states.reshape(-1, self.intermediate_size)
         audio_embeds = self.mm_projector(audio_hidden_states)
-        return audio_embeds
+        return audio_embeds.unsqueeze(0)  # (1, audio_embed_len, hidden_dim)
 
 
 class MultiModalTextToTextExportableModule(torch.nn.Module):

--- a/tests/models/test_modeling_voxtral.py
+++ b/tests/models/test_modeling_voxtral.py
@@ -57,7 +57,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             use_custom_sdpa=True,
             use_custom_kv_cache=True,
             qlinear="8da4w",
-            qembedding="8w",
+            qembedding="4w",
         )
 
         ep = module.export()
@@ -184,7 +184,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             use_custom_sdpa=True,
             use_custom_kv_cache=True,
             qlinear="8da4w",
-            qembedding="8w",
+            qembedding="4w",
         )
         ep = module.export()
 

--- a/tests/models/test_modeling_voxtral.py
+++ b/tests/models/test_modeling_voxtral.py
@@ -89,7 +89,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
                 .forward(
                     input_features=inputs["input_features"],
                 )
-            )
+            ).squeeze(dim=0)
 
         audio_token_mask = inputs["input_ids"] == config.audio_token_id
         token_embeddings[audio_token_mask] = audio_embeddings
@@ -212,7 +212,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
                     input_features=input_features,
                 )
             )
-        audio_embeddings = audio_embeddings.unsqueeze(0)  # Unsqueeze from (1125, 3072) to (1, 1125, 3072)
+        # audio_embeddings = audio_embeddings.unsqueeze(0)  # Unsqueeze from (1125, 3072) to (1, 1125, 3072)
         audio_embeddings_len = audio_embeddings.shape[1]
         logits = (
             ep["decoder"]


### PR DESCRIPTION
To avoid unsqueezing in the C++ runner